### PR TITLE
Fix object comparison with nil in composite primary keys

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -133,6 +133,10 @@ module ActiveRecord
         id
       end
 
+      def ==(comparison_object)
+        ids.is_a?(Array) ? super(comparison_object) && ids.all? {|id| id.present?} : super(comparison_object)
+      end
+
       # Cloned objects have no id assigned and are treated as new records. Note that this is a "shallow" clone
       # as it copies the object's attributes only, not its associations. The extent of a "deep" clone is
       # application specific and is therefore left to the application to implement according to its need.


### PR DESCRIPTION
cpk object comparison lead to unexpected result with nil in primary keys, which is different from normal object.

for example:

a = AnyModel.new
a.relations << ModelWithoutCpk.new
a.relations << ModelWithoutCpk.new
a.relations.size    # => 2

b = OtherModel.new
b.relations << ModelWithCpk.new
b.relations << ModelWithCpk.new
b.relations.size    # => 1  !!
