### PR TITLE
Fixing AssociationReflection#primary_key_name for polymorphic relationships

### DIFF
--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -9,7 +9,7 @@ module ActiveRecord
           #"#{name}_id"
           class_name.foreign_key
         elsif options[:as]
-          options[:as]
+          "#{options[:as]}_id"
         else
           active_record.name.foreign_key
         end


### PR DESCRIPTION
The has_one/has_many :as option is a Symbol, but primary_key_name should return a string (with "_id" appended). The functionality was broken in this commit: https://github.com/drnic/composite_primary_keys/commit/dbdd9bf608f4345632673a21e9eecc3c46f72c9e
