### PR TITLE
improve sqlite unit tests

### DIFF
--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -164,3 +164,9 @@ create table seats (
   customer integer,
   primary key (flight_number, seat)
 );
+
+create table capitols (
+  country text not null,
+  city text not null,
+  primary key (country, city)
+);


### PR DESCRIPTION
The sqlite test schema definition was missing the capitols table so a lot of the tests failed.  This patch includes that definition.
