### PR TITLE
Bugfix for belongs_to with includes

### DIFF
--- a/lib/composite_primary_keys/associations.rb
+++ b/lib/composite_primary_keys/associations.rb
@@ -128,7 +128,8 @@ module ActiveRecord
                                           parent_table, reflection.options[:primary_key] || parent.primary_key)
               end
             when :belongs_to
-              [aliased_table[options[:primary_key] || reflection.klass.primary_key].eq(parent_table[options[:foreign_key] || reflection.primary_key_name])]
+              #[aliased_table[options[:primary_key] || reflection.klass.primary_key].eq(parent_table[options[:foreign_key] || reflection.primary_key_name])]
+              composite_join_predicates(aliased_table, options[:primary_key] || reflection.klass.primary_key, parent_table, options[:foreign_key] || reflection.primary_key_name)
             end
 
             unless klass.descends_from_active_record?

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -93,6 +93,11 @@ class TestAssociations < ActiveSupport::TestCase
     assert_not_nil @product_tariffs.first.instance_variable_get('@tariff'), '@tariff not set'
   end
 
+  def test_new_style_includes_with_conditions
+    product_tariff = ProductTariff.includes(:tariff).where('tariffs.amount < 5').first
+    assert_equal(0, product_tariff.tariff.amount)
+  end
+
   def test_find_includes_extended
     assert @products = Product.find(:all, :include => {:product_tariffs => :tariff})
     assert_equal 3, @products.inject(0) {|sum, product| sum + product.instance_variable_get('@product_tariffs').length},


### PR DESCRIPTION
This is a simple bugfix to the 3.1 series of the gem.  That version of the gem throws errors for the following scenario:

ProductTariff.includes(:tariff).where('tariffs.amount < 5').first

(Where ProductTariff belongs_to Tariff using composite keys).

This does not appear to be broken in the 4.0.beta version... but maybe it would be good to add the test there anyway, just to be safe.

This may be the fix to the following issue:  http://github.com/drnic/composite_primary_keys/issues/33
