### PR TITLE
Make criteria for outputting deprecation warning about extra columns in join table CPK-aware

### DIFF
--- a/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
+++ b/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
@@ -1,6 +1,14 @@
 module ActiveRecord
   module Associations
     class HasAndBelongsToManyAssociation
+
+      def initialize(owner, reflection)
+        super
+        if (columns.size - reflection.cpk_primary_key.size - reflection.association_foreign_key.size) > 0
+          ActiveSupport::Deprecation.warn "Having additional attributes on the join table of a has_and_belongs_to_many association is deprecated and willbe removed in Rails 3.1. Please use a has_many :through association instead."
+        end
+      end
+
       def construct_sql
         if @reflection.options[:finder_sql]
           @finder_sql = interpolate_and_sanitize_sql(@reflection.options[:finder_sql])


### PR DESCRIPTION
The base code outputs a deprecation warning on the initialization of a HABTM association if there are more than two columns in a join table. I modified this criteria to take CPKs into account, so the warning should only be displayed if the number of columns in the join table exceeds the number of columns needed to represent the primary keys of the joined tables.
