### PR TITLE
Fix AssociationReflection#derive_primary_key for belongs_to relationships

### DIFF
--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -5,9 +5,7 @@ module ActiveRecord
         if options[:foreign_key]
           options[:foreign_key]
         elsif belongs_to?
-          #CPK
-          #"#{name}_id"
-          class_name.foreign_key
+          "#{name}_id"
         elsif options[:as]
           "#{options[:as]}_id"
         else


### PR DESCRIPTION
Fix AssociationReflection#derive_primary_key for belongs_to relationships

We just revert to Rails' default way of guessing the foreign_key
when the foreign_key param is not specified.
