### PR TITLE
relax ActiveRecord dependency using ~>

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 1.8.7'
-  s.add_dependency('activerecord', '= 3.1.0.rc5')
+  s.add_dependency('activerecord', '~> 3.1.0.rc5')
 end

--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -26,7 +26,7 @@ $:.unshift(File.dirname(__FILE__)) unless
 
 unless defined?(ActiveRecord)
   require 'rubygems'
-  gem 'activerecord', '= 3.1.0.rc5'
+  gem 'activerecord', '~> 3.1.0.rc5'
   require 'active_record'
 end
 


### PR DESCRIPTION
This relaxes the AR dependency from `= 3.1.0.rc5` to `~> 3.1.0.rc5`.

I have tested this dependency with our application and a local copy of rails by modifying the version.rb file and running `rake update_versions`. The spermy operator works as expected; here are the versions I tested with:
- 3.1.0.rc3 -- not support
- 3.2 -- not supported
- 3.1.0.rc5 -- supported
- 3.1.0.rc6 -- supported
- 3.1.0.rc7 -- supported
- 3.1.0 -- supported
- 3.1.1 -- supported
- 3.1.5 -- supported
