### PR TITLE
Eliminate relative paths from the test suite.

### DIFF
--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -2,7 +2,7 @@ PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 require "pp"
 require "test/unit"
-require "./hash_tricks"
+require File.expand_path('../hash_tricks', __FILE__)
 
 # To make debugging easier, test within this source tree versus an installed gem
 #require 'composite_primary_keys'

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestAssociations < ActiveSupport::TestCase
   fixtures :articles, :products, :tariffs, :product_tariffs, :suburbs, :streets, :restaurants,

--- a/test/test_attribute_methods.rb
+++ b/test/test_attribute_methods.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestAttributeMethods < ActiveSupport::TestCase
   fixtures :reference_types

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestAttributes < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes, :products, :tariffs, :product_tariffs

--- a/test/test_composite_arrays.rb
+++ b/test/test_composite_arrays.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class CompositeArraysTest < ActiveSupport::TestCase
 

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestCreate < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes, :streets, :suburbs

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestDelete < ActiveSupport::TestCase
   fixtures :departments, :employees, :products, :product_tariffs,

--- a/test/test_dup.rb
+++ b/test/test_dup.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestClone < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes

--- a/test/test_equal.rb
+++ b/test/test_equal.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestEqual < ActiveSupport::TestCase
   fixtures :capitols

--- a/test/test_exists.rb
+++ b/test/test_exists.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestExists < ActiveSupport::TestCase
   fixtures :articles, :departments

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 # Testing the find action on composite ActiveRecords with two primary keys
 class TestFind < ActiveSupport::TestCase

--- a/test/test_habtm.rb
+++ b/test/test_habtm.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestHabtm < ActiveSupport::TestCase
   fixtures :suburbs, :restaurants, :restaurants_suburbs, :products

--- a/test/test_ids.rb
+++ b/test/test_ids.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestIds < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes

--- a/test/test_miscellaneous.rb
+++ b/test/test_miscellaneous.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestMiscellaneous < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes, :products

--- a/test/test_pagination.rb
+++ b/test/test_pagination.rb
@@ -1,4 +1,4 @@
-#require './abstract_unit'
+#require File.expand_path('../abstract_unit', __FILE__)
 #require 'plugins/pagination'
 #
 #class TestPagination < ActiveSupport::TestCase

--- a/test/test_polymorphic.rb
+++ b/test/test_polymorphic.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestPolymorphic < ActiveSupport::TestCase
   fixtures :users, :employees, :comments, :hacks

--- a/test/test_predicates.rb
+++ b/test/test_predicates.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestEqual < ActiveSupport::TestCase
   fixtures :departments

--- a/test/test_santiago.rb
+++ b/test/test_santiago.rb
@@ -1,6 +1,6 @@
 # Test cases devised by Santiago that broke the Composite Primary Keys
 # code at one point in time. But no more!!!
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestSantiago < ActiveSupport::TestCase
   fixtures :suburbs, :streets, :users, :articles, :readings

--- a/test/test_suite.rb
+++ b/test/test_suite.rb
@@ -1,22 +1,26 @@
 require 'test/unit'
 
-require './test_associations'
-require './test_attribute_methods'
-require './test_attributes'
-require './test_composite_arrays'
-require './test_create'
-require './test_delete'
-require './test_dup'
-require './test_equal'
-require './test_exists'
-require './test_find'
-require './test_habtm'
-require './test_ids'
-require './test_miscellaneous'
-require './test_pagination'
-require './test_polymorphic'
-require './test_predicates'
-require './test_santiago'
-require './test_tutorial_example'
-require './test_update'
-require './test_validations'
+%w(
+  test_associations
+  test_attribute_methods
+  test_attributes
+  test_composite_arrays
+  test_create
+  test_delete
+  test_dup
+  test_equal
+  test_exists
+  test_find
+  test_habtm
+  test_ids
+  test_miscellaneous
+  test_pagination
+  test_polymorphic
+  test_predicates
+  test_santiago
+  test_tutorial_example
+  test_update
+  test_validations
+).each do |test|
+  require File.expand_path("../#{test}", __FILE__)
+end

--- a/test/test_tutorial_example.rb
+++ b/test/test_tutorial_example.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestTutorialExample < ActiveSupport::TestCase
   fixtures :users, :groups, :memberships, :membership_statuses

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestUpdate < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes

--- a/test/test_validations.rb
+++ b/test/test_validations.rb
@@ -1,4 +1,4 @@
-require './abstract_unit'
+require File.expand_path('../abstract_unit', __FILE__)
 
 class TestValidations < ActiveSupport::TestCase
   fixtures :seats


### PR DESCRIPTION
Converting all wd-relative requires into file-relative requires allows the
test suite to be executed either from rake or directly, and from any
directory. All of the following now work:

```
cd [cpk-root]
rake postgresql:test
ruby test/test_suite.rb
cd test
ruby test_suite.rb
```
