### PR TITLE
Fix polymorphic test failure on PostgreSQL 8.3+ and Oracle

### DIFF
--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -7,10 +7,10 @@ comment2:
   id: 2
   person_id: 1
   person_type: User
-  hack_id: andrew
+  hack_id: 7
   
 comment3:
   id: 3
-  person_id: andrew
+  person_id: 7
   person_type: Hack
   

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -105,15 +105,16 @@ create table employees (
 
 create table comments (
     id int(11) not null auto_increment,
-    person_id varchar(100) default null,
+    person_id int(11) default null,
     person_type varchar(100) default null,
-    hack_id varchar(100) default null,
+    hack_id int(11) default null,
     primary key (id)
 ) type=InnoDB;
 
 create table hacks (
+    id int(11) not null auto_increment,
     name varchar(50) not null,
-    primary key (name)
+    primary key (id)
 ) type=InnoDB;
 
 create table restaurants (

--- a/test/fixtures/db_definitions/oracle.drop.sql
+++ b/test/fixtures/db_definitions/oracle.drop.sql
@@ -25,6 +25,7 @@ drop sequence employees_seq;
 drop table comments;
 drop sequence comments_seq;
 drop table hacks;
+drop sequence hacks_seq;
 drop table restaurants;
 drop table restaurants_suburbs;
 drop table dorms;

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -115,13 +115,16 @@ create sequence comments_seq start with 1000;
 
 create table comments (
     id          number(11)   not null primary key,
-    person_id   varchar(100) default null,
+    person_id   number(11)   default null,
     person_type varchar(100) default null,
-    hack_id     varchar(100) default null
+    hack_id     number(11)   default null
 );
 
+create sequence hacks_seq start with 1000;
+
 create table hacks (
-    name varchar(50) not null primary key
+    id   number(11)  not null primary key,
+    name varchar(50) not null
 );
 
 create table restaurants (

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -125,15 +125,18 @@ create sequence public.comments_seq start 1000;
 
 create table comments (
     id          int          not null default nextval('public.comments_seq'),
-    person_id   varchar(100) default null,
+    person_id   int          default null,
     person_type varchar(100) default null,
-    hack_id     varchar(100) default null,
+    hack_id     int          default null,
     primary key (id)
 );
 
+create sequence public.hacks_seq start 1000;
+
 create table hacks (
+    id   int         default nextval('public.hacks_seq'),
     name varchar(50) not null,
-    primary key (name)
+    primary key (id)
 );
 
 create table restaurants (

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -95,14 +95,15 @@ create table employees (
 );
 
 create table comments (
-	id integer not null primary key autoincrement,
-	person_id varchar(100) null,
-	person_type varchar(100) null,
-	hack_id varchar(100) null
+    id integer not null primary key autoincrement,
+    person_id int null,
+    person_type varchar(100) null,
+    hack_id int null
 );
 
 create table hacks (
-    name varchar(50) not null primary key
+    id integer not null primary key autoincrement,
+    name varchar(50) not null
 );
 
 create table restaurants (

--- a/test/fixtures/hack.rb
+++ b/test/fixtures/hack.rb
@@ -1,5 +1,4 @@
 class Hack < ActiveRecord::Base
-  set_primary_keys :name
   has_many :comments, :as => :person
   
   has_one :first_comment, :as => :person, :class_name => "Comment"

--- a/test/fixtures/hacks.yml
+++ b/test/fixtures/hacks.yml
@@ -1,2 +1,3 @@
 andrew:
+  id: 7
   name: andrew

--- a/test/test_polymorphic.rb
+++ b/test/test_polymorphic.rb
@@ -4,13 +4,13 @@ class TestPolymorphic < ActiveSupport::TestCase
   fixtures :users, :employees, :comments, :hacks
   
   def test_polymorphic_has_many
-    comments = Hack.find('andrew').comments
-    assert_equal 'andrew', comments[0].person_id
+    comments = Hack.find(7).comments
+    assert_equal 7, comments[0].person_id
   end
 
   def test_polymorphic_has_one
-    first_comment = Hack.find('andrew').first_comment
-    assert_equal 'andrew', first_comment.person_id
+    first_comment = Hack.find(7).first_comment
+    assert_equal 7, first_comment.person_id
   end
 
   def test_has_many_through


### PR DESCRIPTION
When running the tests in master under PostgreSQL 8.3 or later, `TestPolymorphic#test_polymorphic_has_many_through` fails:

```
ActiveRecord::StatementInvalid: PGError: ERROR:  operator does not exist: character varying = integer
LINE 1: ...ame" = "comments"."hack_id" WHERE "comments"."person_id" = 1
                                                                    ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
: SELECT "hacks".* FROM "hacks" INNER JOIN "comments" ON "hacks"."name" = "comments"."hack_id" WHERE "comments"."person_id" = 1
```

(It fails for a similar reason [though with a more obscure error message] on Oracle as well.)

The immediate cause here is that PostgreSQL 8.3+ is much stricter about implicit type conversions. The proximate cause is that the schema design for the polymorphic tests is a bit odd — comments.person_id is an FK to three different tables, two with integer PKs and one with a string PK. While this works on older versions of PostgreSQL (and on MySQL and SQLite), PostgreSQL 8.3+ and Oracle would require special handling in the main library to support this sort of schema. 

Since I don't see any evidence in the project history that these tests are specifically trying to test that CPK supports an FK of a different type from the PK to which it refers, this pull request normalizes the relationship between comments and the three tables it references by giving the `hacks` table an integer PK and changing `comments.person_id` to an integer. This allows `TestPolymorphic#test_polymorphic_has_many_through` to pass.

N.b.: after applying this change, you'll need to rebuild your test database to see the fix applied. I've tested the changes on PostgreSQL, SQLite3, and Oracle, but not on MySQL (this pull includes an updated schema for MySQL, but I haven't tested it). I did not include changes for the DB2 schema because it doesn't include the relevant tables.
