### PR TITLE
Add missing fixture declarations.

### DIFF
--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -3,7 +3,7 @@ require './abstract_unit'
 class TestAssociations < ActiveSupport::TestCase
   fixtures :articles, :products, :tariffs, :product_tariffs, :suburbs, :streets, :restaurants,
            :dorms, :rooms, :room_attributes, :room_attribute_assignments, :students, :room_assignments, :users, :readings,
-           :departments, :memberships
+           :departments, :employees, :memberships, :membership_statuses
   
   def test_count
     assert_equal(3, Product.count(:include => :product_tariffs))

--- a/test/test_attribute_methods.rb
+++ b/test/test_attribute_methods.rb
@@ -1,7 +1,7 @@
 require './abstract_unit'
 
 class TestAttributeMethods < ActiveSupport::TestCase
-  fixtures :reference_types
+  fixtures :reference_types, :reference_codes
 
   def test_read_attribute_with_single_key
     rt = ReferenceType.find(1)


### PR DESCRIPTION
`TestAttributeMethods` and `TestAssociations` were missing declarations for some of the fixtures on which they rely. This caused them to confusingly fail the first time the suite was executed on a clean schema and then pass on subsequent runs.
