### PR TITLE
Make polymorphic belongs_to work in rails 3.1.1

### DIFF
--- a/lib/composite_primary_keys/associations/association_scope.rb
+++ b/lib/composite_primary_keys/associations/association_scope.rb
@@ -24,7 +24,12 @@ module ActiveRecord
           end
 
           if reflection.source_macro == :belongs_to
-            key         = reflection.association_primary_key
+            if reflection.options[:polymorphic]
+              key = reflection.association_primary_key(klass)
+            else
+              key = reflection.association_primary_key
+            end
+
             foreign_key = reflection.foreign_key
           else
             key         = reflection.foreign_key


### PR DESCRIPTION
A polymorphic belongs_to fails on a class with a composite primary key in rails 3.1.1 due to a change in active_record/associations/association_scope.rb and this change updates CPK with that change.
