### PR TITLE
2.3.5 hotfix branch enables c_p_k to work with activerecord 2.3.x

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/sqlite3_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/sqlite3_adapter.rb
@@ -1,4 +1,4 @@
-require 'active_record/connection_adapters/sqlite_adapter'
+require 'active_record/connection_adapters/sqlite3_adapter'
 
 module ActiveRecord
   module ConnectionAdapters #:nodoc:


### PR DESCRIPTION
Any chance you could create a 2.3.5.2 version for unlucky souls like me that need c_p_k to work with v2.3.x of ActiveRecord, et al. ?

There might be other fixes worthy of back porting as well, but these two commits were all I needed to unblock me.

I'm using jruby, activerecord-jdbc-adapter v1.2.0, activerecord-oracle_enhanced-adapter v1.4.0, and activerecord/resource/support v2.3.x.
