### PR TITLE
Fix cpk_or_predicate issue when using multiple database connections

### DIFF
--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -8,11 +8,13 @@ module CompositePrimaryKeys
       end
     end
     
-    def cpk_or_predicate(predicates)
+    def cpk_or_predicate(predicates, table = nil)
       # Can't do or here, arel does the wrong thing and makes a really
       # deeply nested stack that blows up
+      engine = table && table.engine
       predicates = predicates.map do |predicate|
-        "(#{predicate.to_sql})"
+        predicate_sql = engine ? predicate.to_sql(engine) : predicate.to_sql
+        "(#{predicate_sql})"
       end
       predicates = "(#{predicates.join(" OR ")})"
       Arel::Nodes::SqlLiteral.new(predicates)
@@ -43,7 +45,7 @@ module CompositePrimaryKeys
         cpk_and_predicate(eq_predicates)
       end
 
-      cpk_or_predicate(and_predicates)
+      cpk_or_predicate(and_predicates, table)
     end
   end
 end


### PR DESCRIPTION
CompositePrimaryKeys::Predicates#cpk_or_predicate was making calls to Arel::Node#to_sql without specifying an engine. By default, to_sql falls back to Arel::Table.engine, which is typically set to ActiveRecord::Base. This works fine for most apps that only connect to a single database, but if the model we're generating a predicate for connects to a different database, the table cache lookup fails and ARel/ActiveRecord executes an unnecessary "SHOW TABLES" request every time.

CPK is aware of the table we're generating the predicate for, so this fix supplies the table's engine (and through that, the correct connection) to Arel::Node#to_sql.
