### PR TITLE
Fix nonsensical deprecation warning

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
       def set_primary_keys(*keys)
         ActiveSupport::Deprecation.warn(
-            "Calling self.primary_keys = is deprecated. Please use `self.primary_keys = keys` instead."
+            "Calling set_primary_keys is deprecated. Please use `self.primary_keys = keys` instead."
         )
 
         keys = keys.first if keys.first.is_a?(Array)


### PR DESCRIPTION
The new warning about set_primary_keys is worded wrongly and actually tells you the new syntax is deprecated... This commit corrects it.
