### PR TITLE
fix method signature mismatch with active_record

### DIFF
--- a/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
+++ b/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
@@ -1,8 +1,14 @@
 module ActiveRecord
   module Associations
     class HasAndBelongsToManyAssociation
-      def insert_record(record, validate = true)
-        return if record.new_record? && !record.save(:validate => validate)
+      def insert_record(record, validate = true, raise = false)
+        if record.new_record?
+          if raise
+            record.save!(:validate => validate)
+          else
+            return unless record.save(:validate => validate)
+          end
+        end
 
         if options[:insert_sql]
           owner.connection.insert(interpolate(options[:insert_sql], record))


### PR DESCRIPTION
I was trying to set up a has_and_belongs_to_many association and kept receiving the following exception:

ArgumentError: wrong number of arguments (3 for 2)
    from /Library/Ruby/Gems/1.8/gems/activerecord-3.2.2/lib/active_record/associations/collection_association.rb:435:in `insert_record'

Upon inspection I noticed the offending line in active_record is trying to call the following method:

insert_record(record, true, raise)

However, the corresponding method in composite_primary_keys has an incompatible signature:

def insert_record(record, validate = true)

Should be fixed now.
