### PR TITLE
Remove test_composite_keys_equality

### DIFF
--- a/test/test_composite_arrays.rb
+++ b/test/test_composite_arrays.rb
@@ -21,11 +21,4 @@ class CompositeArraysTest < ActiveSupport::TestCase
     assert_equal CompositePrimaryKeys::CompositeKeys, keys.class
     assert_equal '1,2,3', keys.to_s
   end
-
-  def test_composite_keys_equality
-    keys_array_1 = [1, Time.now].to_composite_keys
-    keys_array_2 = [1, Time.now].to_composite_keys
-    assert keys_array_1 == keys_array_2
-    assert keys_array_1.eql? keys_array_2
-  end
 end


### PR DESCRIPTION
Undoes da4ae437e2b6635bb6d8cb4c3e9451ff0cd27016

String based comparison proposed in #89 wasn't accepted so this test couldn't pass.
