### PR TITLE
to_param should join with comma instead of minus sign

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -148,6 +148,10 @@ module ActiveRecord
       def to_key
         ids.to_a if !ids.compact.empty? # XXX Maybe use primary_keys with send instead of ids
       end
+      
+      def to_param
+        persisted? ? to_key.join(CompositePrimaryKeys::ID_SEP) : nil
+      end
     end
   end
 end

--- a/test/test_ids.rb
+++ b/test/test_ids.rb
@@ -32,6 +32,12 @@ class TestIds < ActiveSupport::TestCase
     end
   end
 
+  def test_to_param
+    testing_with do
+      assert_equal '1,1', @first.to_param if composite?
+    end
+  end
+
   def test_ids_to_s
     testing_with do
       order = @klass.primary_key.is_a?(String) ? @klass.primary_key : @klass.primary_key.join(',')


### PR DESCRIPTION
This patch overrides `to_param` of ActiveModel::Conversion, which joins ids with minus sign.

I wrote a test for this patch, but I am not sure if the position is correct and I wrote it in a suitable way.

Please instruct me if I am wrong.
