### PR TITLE
Fix for this error when running rake mysql:rebuild_databases:

### DIFF
--- a/tasks/databases/mysql.rake
+++ b/tasks/databases/mysql.rake
@@ -19,7 +19,9 @@ namespace :mysql do
       file.read
     end
 
+    Rake::Task['mysql:load_connection'].reenable
     Rake::Task['mysql:load_connection'].invoke
+    #puts %(ActiveRecord::Base.connection.instance_variable_get(:@config)=#{(ActiveRecord::Base.connection.instance_variable_get(:@config)).inspect})
     ActiveRecord::Base.connection.execute(sql)
   end
 
@@ -33,5 +35,6 @@ namespace :mysql do
   
   task :load_connection do
     require File.join(PROJECT_ROOT, "test", "connections", "native_mysql", "connection")
+    establish_connection
   end
 end

--- a/test/connections/native_mysql/connection.rb
+++ b/test/connections/native_mysql/connection.rb
@@ -8,6 +8,10 @@ def connection_string
   options.map { |key, value| "-#{key}#{value}" }.join(" ")
 end
 
-# Adapter config setup in text/connections/databases.yml
+# Adapter config setup in test/connections/databases.yml
 SPEC = CompositePrimaryKeys::ConnectionSpec['mysql']
-ActiveRecord::Base.establish_connection(SPEC)
+
+def establish_connection
+  ActiveRecord::Base.establish_connection(SPEC)
+end
+establish_connection


### PR DESCRIPTION
Mysql::Error: No database selected: create table reference_types (...

The problem was that task :create_database was establishing a connection
without the database, and we never subsequently established a connection
_with_ the database selected which is needed for running the 'create
table' SQL.

We have to reenable the 'mysql:load_connection' task so that it will
actually be executed again when invoked again (it was _first_ invoked as
a prerequisite of mysql:drop_databases.)
