### PR TITLE
Setting a belongs_to association to nil raise an error (NoMethodError: undefined method `length' for nil:NilClass)

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/write.rb
+++ b/lib/composite_primary_keys/attribute_methods/write.rb
@@ -4,6 +4,7 @@ module ActiveRecord
       def write_attribute(attr_name, value)
         # CPK
         if attr_name.kind_of?(Array)
+          value = [nil]*attr_name.length if value.nil?
           unless value.length == attr_name.length
             raise "Number of attr_names and values do not match"
           end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -176,6 +176,13 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal({:department_id=>[1, 2]}, steve.changes)
   end
 
+  def test_composite_belongs_to__setting_to_nil
+    room_assignment = room_assignments(:jacksons_room)
+    # This was raising an error before:
+    #   NoMethodError: undefined method `length' for nil:NilClass
+    assert_nothing_raised { room_assignment.room = nil }
+  end
+
   def test_has_one_with_composite
     # In this case a regular model has_one composite model
     department = departments(:engineering)


### PR DESCRIPTION
ActiveRecord will set this "attribute" to nil right here:

```
    def replace_keys(record)
      if record
        owner[reflection.foreign_key] = record[reflection.association_primary_key(record.class)]
      else
        owner[reflection.foreign_key] = nil
      end
    end
```

so we need to allow nil as a valid value.
