### PR TITLE
Fix associations tests

### DIFF
--- a/test/fixtures/room.rb
+++ b/test/fixtures/room.rb
@@ -6,6 +6,6 @@ class Room < ActiveRecord::Base
   has_many :room_attributes, :through => :room_attribute_assignments
   
   def find_custom_room_attributes
-    room_attributes.find(:all, :conditions => ["room_attributes.name != ?", "keg"])
+    room_attributes.find(:all, :conditions => ["room_attributes.name != ?", "type"])
   end
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -133,7 +133,7 @@ class TestAssociations < ActiveSupport::TestCase
     dorm = Dorm.find(:first)
     assert_equal(2, dorm.rooms.length)
     assert_equal(1, dorm.rooms.first.room_attributes.length)
-    assert_equal('keg', dorm.rooms.first.room_attributes.first.name)
+    assert_equal('type', dorm.rooms.first.room_attributes.first.name)
   end
 
   def test_associations_with_conditions
@@ -237,7 +237,7 @@ class TestAssociations < ActiveSupport::TestCase
 
   def test_has_many_through_with_conditions_when_through_association_is_composite
     room = Room.find(:first)
-    assert_equal 0, room.room_attributes.find(:all, :conditions => ["room_attributes.name != ?", "keg"]).size
+    assert_equal 0, room.room_attributes.find(:all, :conditions => ["room_attributes.name != ?", "type"]).size
   end
 
   def test_has_many_through_on_custom_finder_when_through_association_is_composite_finder_when_through_association_is_not_composite


### PR DESCRIPTION
It seems that recent changes introduced in 6143ed5cdcc2b0086520b4d83104f206b1a0f084 have broken tests. I am only assuming that tests should be adapted this way, but they're passing now.

I would like to give Travis-CI a spin for CPK (if you are interested), it would make checking for these errors much easier.
