### PR TITLE
convert float and decimal to int for association preload

### DIFF
--- a/lib/composite_primary_keys/associations/preloader/association.rb
+++ b/lib/composite_primary_keys/associations/preloader/association.rb
@@ -34,7 +34,7 @@ module ActiveRecord
             # CPK
             # owner_key = record[association_key_name].to_s
             owner_key = Array(association_key_name).map do |key_name|
-              record[key_name]
+              record[key_name].class == BigDecimal || record[key_name].class == Float ? record[key_name].to_i : record[key_name]
             end.join(CompositePrimaryKeys::ID_SEP)
 
             owners_map[owner_key].each do |owner|


### PR DESCRIPTION
Several db's I write tools for have BigDecimal primary keys.  Rails and CPK handle this very well except for when I try to do eager loading of associations.  This patch fixes this problem for me and I don't think it will cause any problems, but please let me know if you think otherwise.  I can demonstrate this with a simple app but couldn't see an easy way to write a failing test to the project without adding new tables/models/associations.  If this is the preferred approach let me know and I will.
