### PR TITLE
Fixed problem loading jdbcpostgresql adapter

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
@@ -1,8 +1,8 @@
 module ActiveRecord
   class Base
     def self.load_cpk_adapter(adapter)
-      if adapter.to_s == 'postgresql'
-        require "composite_primary_keys/connection_adapters/#{adapter}_adapter.rb"
+      if adapter.to_s =~ /postgresql/
+        require "composite_primary_keys/connection_adapters/postgresql_adapter.rb"
       end
     end
     


### PR DESCRIPTION
Used a regex to check for postgresql adapter and hard wire to composite_primary_keys/connection_adapters/postgresql_adapter.rb.
There doesn't appear to be anything jdbc specific for postgresql cpk.
