### PR TITLE
Make cpk_in_predicate build a simple IN when possible

### DIFF
--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -49,14 +49,19 @@ module CompositePrimaryKeys
     end
 
     def cpk_in_predicate(table, primary_keys, ids)
-      and_predicates = ids.map do |id_set|
-        eq_predicates = Array(primary_keys).zip(Array(id_set)).map do |primary_key, value|
-          table[primary_key].eq(value)
+      primary_keys = Array(primary_keys)
+      if primary_keys.length > 1
+        and_predicates = ids.map do |id_set|
+          eq_predicates = Array(primary_keys).zip(Array(id_set)).map do |primary_key, value|
+            table[primary_key].eq(value)
+          end
+          cpk_and_predicate(eq_predicates)
         end
-        cpk_and_predicate(eq_predicates)
-      end
 
-      cpk_or_predicate(and_predicates, table)
+        cpk_or_predicate(and_predicates, table)
+      else
+        table[primary_keys.first].in(ids.flatten)
+      end
     end
   end
 end


### PR DESCRIPTION
If there is only a single key element then build an IN predicate instead of a long list of equality comparisons joined together.

The IN is probably more efficient and certainly Postgres at least can run into stack overflow issues trying to analyse a very long list of ORs.
