### PR TITLE
Load postgresql_adapter.rb with postgis-adapter

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   class Base
     def self.load_cpk_adapter(adapter)
-      if adapter.to_s =~ /postgresql/
+      if (adapter.to_s =~ /postgresql/) or (adapter.to_s =~ /postgis/)
         require "composite_primary_keys/connection_adapters/postgresql_adapter.rb"
       end
     end


### PR DESCRIPTION
When using the activerecord-postgis-adapter `composite_primary_keys/connection_adapters/postgresql_adapter.rb` didn't get loaded, because the adapter name does not match postgresql, but activerecord-postgis-adapter uses the postgresql adapter under the hood and it should be loaded. Solves the same problem with `INSERT ... RETURNING` statements as commit 112c756c6114178629f65400e3b075de164f8381 did for the postgresql adapter.
