### PR TITLE
Update ActiveRecord::Base#initialize_dup override in line with ActiveRec...

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -59,6 +59,7 @@ module ActiveRecord
 
     def initialize_dup(other)
       cloned_attributes = other.clone_attributes(:read_attribute_before_type_cast)
+      self.class.initialize_attributes(cloned_attributes, :serialized => false)
       # CPK
       # cloned_attributes.delete(self.class.primary_key)
       Array(self.class.primary_key).each {|key| cloned_attributes.delete(key.to_s)}
@@ -148,7 +149,7 @@ module ActiveRecord
       def to_key
         ids.to_a if !ids.compact.empty? # XXX Maybe use primary_keys with send instead of ids
       end
-      
+
       def to_param
         persisted? ? to_key.join(CompositePrimaryKeys::ID_SEP) : nil
       end


### PR DESCRIPTION
...ord::Base 3.2.5+

initialize_attributes is included from ActiveRecord::AttributeMethods::Serialization and since 3.2.5 accepts
an options hash which can control whether or not the attributes are initialized serialized or unserialized.

This fixes issue #119, however it will make things incompatible with ActiveRecord < 3.2.5. Not sure how version support should be handled here.
