### PR TITLE
destroy_all and nil attributes

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -10,24 +10,20 @@ module ActiveRecord
         #column     = self.class.columns_hash[pk]
         #substitute = connection.substitute_at(column, 0)
 
+        where_hash = {}
         primary_keys = Array(self.class.primary_key)
-        bind_values = Array.new
-        eq_predicates = Array.new
-        primary_keys.each_with_index do |key, i|
-          column = self.class.columns_hash[key.to_s]
-          bind_values << [column, self[key]]
-          substitute = connection.substitute_at(column, i)
-          eq_predicates << self.class.arel_table[key].eq(substitute)
-        end
-        predicate = Arel::Nodes::And.new(eq_predicates)
-        relation = self.class.unscoped.where(predicate)
 
         #relation = self.class.unscoped.where(
         #  self.class.arel_table[pk].eq(substitute))
 
-        # CPK
+        primary_keys.each do |key|
+          where_hash[key.to_s] = self[key]
+        end
+
+        # CPK      
         #relation.bind_values = [[column, id]]
-        relation.bind_values = bind_values
+
+        relation = self.class.unscoped.where(where_hash)
         relation.delete_all
       end
 


### PR DESCRIPTION
When defining a composite primary key, one or more of the attributes that make up the key might be nil.  When they are, calling an AR method (such as destroy_all) that calls the overridden destroy() does not work as expected.  Because of the way destroy() is currently defined in composite_primary_keys, you will end up with an SQL delete statement containing "attribute = $x", where $x = NULL.  This is incorrect behavior, because "attribute = NULL" is not the same as "attribute IS NULL" (the latter being the correct way to handle NULLs in the where clause).

An example:

class Bob < ActiveRecord::Base
  attr_accessible :field1, :field2, :field3, :field4

  set_primary_keys :field1, :field2
end

If there is a record in the database with field1 = NULL, field2 = 'whatever', and field4 = 'stuff', calling:

Bob.destroy_all(field4: 'stuff')

Will result in something similar to the following:

SELECT "bobs".\* FROM "bobs" WHERE "bobs"."field4" = 'stuff'
DELETE FROM "bobs" WHERE ("bobs"."field1" = $1 AND "bobs"."field2" = $2)  [["field1", nil], ["field2", 'whatever']]

I will be creating a pull-request shortly with a proposed solution that involves passing a hash of the primary key attribute/val pairs to the where() in destroy() rather than an array of key/pair equalities.  With it in place, the resulting SQL will be:

DELETE FROM "bobs" WHERE "bobs"."field1" IS NULL AND "bobs"."field2" = 'whatever'
