### PR TITLE
Support for #touch method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ db
 
 /doc
 /.idea
+*.swo
+*.swp
 
 test/connections/databases.yml

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -18,14 +18,18 @@ create table reference_codes (
 create table products (
     id serial not null,
     name varchar(50) default null,
-    primary key (id)
+    primary key (id),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 create table tariffs (
     tariff_id  int  not null,
     start_date date not null,
     amount     int  default null,
-    primary key (tariff_id, start_date)
+    primary key (tariff_id, start_date),
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 create table product_tariffs (

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -16,13 +16,17 @@ create table reference_codes (
 
 create table products (
     id int(11) not null primary key,
-    name varchar(50) default null
+    name varchar(50) default null,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP
 );
 
 create table tariffs (
     tariff_id int(11) not null,
     start_date date not null,
     amount integer(11) default null,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
     primary key (tariff_id, start_date)
 );
 

--- a/test/test_touch.rb
+++ b/test/test_touch.rb
@@ -1,0 +1,23 @@
+# Test cases devised by Santiago that broke the Composite Primary Keys
+# code at one point in time. But no more!!!
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestTouch < ActiveSupport::TestCase
+  fixtures :products, :tariffs
+
+  def test_touching_a_record_updates_its_timestamp
+    tariff                = tariffs(:flat)
+    previous_amount       = tariff.amount
+    previously_updated_at = tariff.updated_at
+    
+    tariff.amount         = previous_amount + 1
+    tariff.touch
+
+    assert_not_equal previously_updated_at, tariff.updated_at
+    assert_equal previous_amount + 1, tariff.amount
+    assert tariff.amount_changed?, 'tarif amount should have changed'
+    assert tariff.changed?, 'tarif should be marked as changed'
+    tariff.reload
+    assert_not_equal previously_updated_at, tariff.updated_at
+  end
+end


### PR DESCRIPTION
I was having this issue while trying to touch a record with composite primary keys.

```
      NoMethodError: undefined method `to_sym' for [:state_code, :code]:CompositePrimaryKeys::CompositeKeys
```

I checked AR implementation and tests to fix the issue. Tested under postgres and sqlite.
