### PR TITLE
Compatibility with Rails 3.2.9

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/dirty.rb
+++ b/lib/composite_primary_keys/attribute_methods/dirty.rb
@@ -10,15 +10,17 @@ module ActiveRecord
         else
           attr = attr.to_s
 
+          changed = respond_to?(:_field_changed?, true) && :_field_changed? || :field_changed?
+
           # The attribute already has an unsaved change.
           if attribute_changed?(attr)
             old = @changed_attributes[attr]
-            @changed_attributes.delete(attr) unless field_changed?(attr, old, value)
+            @changed_attributes.delete(attr) unless send(changed, attr, old, value)
           else
             old = clone_attribute_value(:read_attribute, attr)
             # Save Time objects as TimeWithZone if time_zone_aware_attributes == true
             old = old.in_time_zone if clone_with_time_zone_conversion_attribute?(attr, old)
-            @changed_attributes[attr] = old if field_changed?(attr, old, value)
+            @changed_attributes[attr] = old if send(changed, attr, old, value)
           end
         end
 

--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -68,9 +68,11 @@ module ActiveRecord
 
       _run_after_initialize_callbacks if respond_to?(:_run_after_initialize_callbacks)
 
+      changed = respond_to?(:_field_changed?, true) && :_field_changed? || :field_changed?
+
       @changed_attributes = {}
       self.class.column_defaults.each do |attr, orig_value|
-        @changed_attributes[attr] = orig_value if field_changed?(attr, orig_value, @attributes[attr])
+        @changed_attributes[attr] = orig_value if send(changed, attr, orig_value, @attributes[attr])
       end
 
       @aggregation_cache = {}


### PR DESCRIPTION
Rails 3.2.9 renamed #field_changed? to #_field_changed? to allow people to have a field named `field` on their models. This patch just checks for 3.2.9 usage and uses it if available, and falls back to normal behavior otherwise.
