### PR TITLE
Fix for rails 3.2.9

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 1.8.7'
-  s.add_dependency('activerecord', '>= 3.2.8', '~> 3.2.0')
+  s.add_dependency('activerecord', '>= 3.2.9', '~> 3.2.0')
 end

--- a/lib/composite_primary_keys/attribute_methods/dirty.rb
+++ b/lib/composite_primary_keys/attribute_methods/dirty.rb
@@ -13,12 +13,12 @@ module ActiveRecord
           # The attribute already has an unsaved change.
           if attribute_changed?(attr)
             old = @changed_attributes[attr]
-            @changed_attributes.delete(attr) unless field_changed?(attr, old, value)
+            @changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
           else
             old = clone_attribute_value(:read_attribute, attr)
             # Save Time objects as TimeWithZone if time_zone_aware_attributes == true
             old = old.in_time_zone if clone_with_time_zone_conversion_attribute?(attr, old)
-            @changed_attributes[attr] = old if field_changed?(attr, old, value)
+            @changed_attributes[attr] = old if _field_changed?(attr, old, value)
           end
         end
 

--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -70,7 +70,7 @@ module ActiveRecord
 
       @changed_attributes = {}
       self.class.column_defaults.each do |attr, orig_value|
-        @changed_attributes[attr] = orig_value if field_changed?(attr, orig_value, @attributes[attr])
+        @changed_attributes[attr] = orig_value if _field_changed?(attr, orig_value, @attributes[attr])
       end
 
       @aggregation_cache = {}


### PR DESCRIPTION
Fix for renaming of `field_changed?` to `_field_changed?` in rails 3.2.9
