### PR TITLE
Concerning issue 129

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use ruby-1.9.3@rc-logic

--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -27,7 +27,7 @@ module ActiveRecord
           return
         end
 
-        @primary_keys = keys.map { |k| k.to_sym }.to_composite_keys
+        @primary_keys = keys.map { |k| k.to_s }.to_composite_keys
 
         class_eval <<-EOV
           extend  CompositeClassMethods

--- a/lib/composite_primary_keys/dirty.rb
+++ b/lib/composite_primary_keys/dirty.rb
@@ -5,12 +5,12 @@ module ActiveModel
     end
 
     def primary_key_changed?
-      !!changed.detect { |key| ids_hash.keys.include?(key.to_sym) }
+      !!changed.detect { |key| ids_hash.keys.include?(key.to_s) }
     end
 
     def primary_key_was
       ids_hash.keys.inject(Hash.new) do |result, attribute_name|
-        result[attribute_name.to_sym] = attribute_was(attribute_name.to_s)
+        result[attribute_name] = attribute_was(attribute_name.to_s)
         result
       end
     end

--- a/test/test_ids.rb
+++ b/test/test_ids.rb
@@ -78,7 +78,7 @@ class TestIds < ActiveSupport::TestCase
     testing_with do
       if composite?
         assert_not_nil @klass.primary_keys
-        assert_equal @primary_keys.map {|key| key.to_sym}, @klass.primary_keys
+        assert_equal @primary_keys.map {|key| key.to_s}, @klass.primary_keys
         assert_equal @klass.primary_keys, @klass.primary_key
         assert_kind_of(CompositePrimaryKeys::CompositeKeys, @klass.primary_keys)
         assert_equal @primary_keys.map {|key| key.to_sym}.join(','), @klass.primary_key.to_s
@@ -91,7 +91,7 @@ class TestIds < ActiveSupport::TestCase
   end
 
   def test_inherited_primary_keys
-    assert_equal([:reference_type_id, :reference_code], ChildCpkTest.primary_keys)
+    assert_equal(["reference_type_id", "reference_code"], ChildCpkTest.primary_keys)
   end
 
   def test_inherited_ids

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -41,13 +41,13 @@ class TestUpdate < ActiveSupport::TestCase
     obj.reference_type_id = 2
     obj.reference_code = 3
     assert(obj.primary_key_changed?)
-    assert_equal({:reference_type_id => 1, :reference_code => 1}, obj.primary_key_was)
-    assert_equal({:reference_type_id => 2, :reference_code => 3}, obj.ids_hash)
+    assert_equal({"reference_type_id" => 1, "reference_code" => 1}, obj.primary_key_was)
+    assert_equal({"reference_type_id" => 2, "reference_code" => 3}, obj.ids_hash)
     assert(obj.save)
     assert(obj.reload)
     assert_equal(2, obj.reference_type_id)
     assert_equal(3, obj.reference_code)
-    assert_equal({:reference_type_id => 2, :reference_code => 3}, obj.ids_hash)
+    assert_equal({"reference_type_id" => 2, "reference_code" => 3}, obj.ids_hash)
     assert_equal([2, 3], obj.id)
   end
 


### PR DESCRIPTION
...e record, primary key is always a string. this breaks primary key usage in some gems like delayed job
