### PR TITLE
add supporting to _field_changed? in rails 3.2.9

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/dirty.rb
+++ b/lib/composite_primary_keys/attribute_methods/dirty.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       end
 
       def field_changed2?(attr, old, value)
-        if respond_to?(field_changed?)
+        if respond_to?(:field_changed?)
           field_changed?(attr, old, value)
         else
           _field_changed?(attr, old, value)


### PR DESCRIPTION
according to rails 3.2.9 changes (http://weblog.rubyonrails.org/2012/10/29/ann-rails-3-2-9-rc1-has-been-released/) field_changed? is renamed to _field_changed?. And the patch supported the change.
