### PR TITLE
add missing timestamp columns for mysql test_touch.rb; added sleep 0.1 t...

### DIFF
--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -25,6 +25,8 @@ create table tariffs (
     tariff_id int not null,
     start_date date not null,
     amount integer(11) default null,
+    created_at timestamp,
+    updated_at timestamp,
     primary key (tariff_id, start_date)
 );
 

--- a/test/test_touch.rb
+++ b/test/test_touch.rb
@@ -9,10 +9,10 @@ class TestTouch < ActiveSupport::TestCase
     tariff                = tariffs(:flat)
     previous_amount       = tariff.amount
     previously_updated_at = tariff.updated_at
-    
+
     tariff.amount         = previous_amount + 1
     tariff.touch
-
+    sleep 0.1
     assert_not_equal previously_updated_at, tariff.updated_at
     assert_equal previous_amount + 1, tariff.amount
     assert tariff.amount_changed?, 'tarif amount should have changed'


### PR DESCRIPTION
add missing timestamp columns for mysql test_touch.rb; added sleep 0.1 to avoid intermitant failures around the time comparison. 

I had already submitted something similar, but this patch is way cleaner. 

Not sure if the `sleep` is the best way to go...
