### PR TITLE
add test and fix for to_sym exception

### DIFF
--- a/lib/composite_primary_keys/sanitization.rb
+++ b/lib/composite_primary_keys/sanitization.rb
@@ -1,14 +1,51 @@
 module ActiveRecord
   module Sanitization
-    def quoted_id
-      # CPK
-      #quote_value(id, column_for_attribute(self.class.primary_key))
-      if self.composite?
-        [self.class.primary_keys, ids].
-          transpose.
-          map {|attr_name,id| quote_value(id, column_for_attribute(attr_name))}
-      else
-        quote_value(id, column_for_attribute(self.class.primary_key))
+    module ClassMethods
+      protected
+      # Accepts a hash of SQL conditions and replaces those attributes
+      # that correspond to a +composed_of+ relationship with their expanded
+      # aggregate attribute values.
+      # Given:
+      #     class Person < ActiveRecord::Base
+      #       composed_of :address, class_name: "Address",
+      #         mapping: [%w(address_street street), %w(address_city city)]
+      #     end
+      # Then:
+      #     { address: Address.new("813 abc st.", "chicago") }
+      #       # => { address_street: "813 abc st.", address_city: "chicago" }
+      def expand_hash_conditions_for_aggregates(attrs)
+        expanded_attrs = {}
+        attrs.each do |attr, value|
+          if attr.is_a?(CompositePrimaryKeys::CompositeKeys)
+            attr.each_with_index do |key,i|
+              expanded_attrs[key] = value[i]
+            end
+          elsif aggregation = reflect_on_aggregation(attr.to_sym)
+            mapping = aggregation.mapping
+            mapping.each do |field_attr, aggregate_attr|
+              if mapping.size == 1 && !value.respond_to?(aggregate_attr)
+                expanded_attrs[field_attr] = value
+              else
+                expanded_attrs[field_attr] = value.send(aggregate_attr)
+              end
+            end
+          else
+            expanded_attrs[attr] = value
+          end
+        end
+        expanded_attrs
+      end
+
+      def quoted_id
+        # CPK
+        #quote_value(id, column_for_attribute(self.class.primary_key))
+        if self.composite?
+          [self.class.primary_keys, ids].
+            transpose.
+            map {|attr_name,id| quote_value(id, column_for_attribute(attr_name))}
+        else
+          quote_value(id, column_for_attribute(self.class.primary_key))
+        end
       end
     end
   end

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -2,30 +2,30 @@ require File.expand_path('../abstract_unit', __FILE__)
 
 class TestUpdate < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes
-  
+
   CLASSES = {
     :single => {
       :class => ReferenceType,
       :primary_keys => :reference_type_id,
       :update => { :description => 'RT Desc' },
     },
-    :dual   => { 
+    :dual   => {
       :class => ReferenceCode,
       :primary_keys => [:reference_type_id, :reference_code],
       :update => { :description => 'RT Desc' },
     },
   }
-  
+
   def setup
     self.class.classes = CLASSES
   end
-  
+
   def test_setup
     testing_with do
       assert_not_nil @klass_info[:update]
     end
   end
-  
+
   def test_update_attributes
     testing_with do
       assert(@first.update_attributes(@klass_info[:update]))
@@ -35,7 +35,7 @@ class TestUpdate < ActiveSupport::TestCase
       end
     end
   end
-  
+
   def test_update_primary_key
     obj = ReferenceCode.find([1,1])
     obj.reference_type_id = 2
@@ -58,5 +58,15 @@ class TestUpdate < ActiveSupport::TestCase
     assert(obj.save)
     assert(obj.reload)
     assert_equal('b', obj.abbreviation)
+  end
+
+  def test_update_all
+    assert_nothing_raised do
+      refrence_code = ReferenceCode.create
+      primary_key = refrence_code.class.primary_key
+      ReferenceCode.update_all(
+        {description: 'random value'},
+        {primary_key => refrence_code[primary_key]})
+    end
   end
 end


### PR DESCRIPTION
We used to be able to reproduce this error by calling .touch on an AR instance with a cpk.
That seems to be fixed in master. However we were still seeing the exception when using Rails' accepts_nested_attributes.

Tom found a new way to expose the exception that is added in this commit, taken from the AR touch method.

The fix could def be sexier, but i wanted to keep it really obvious in case we could get some better clarity around the issue.

This addresses the same problem as https://github.com/drnic/composite_primary_keys/issues/134. #134 can be closed as a dup.
