### PR TITLE
add test and fix for nested_attributes update

### DIFF
--- a/lib/composite_primary_keys/sanitization.rb
+++ b/lib/composite_primary_keys/sanitization.rb
@@ -18,7 +18,7 @@ module ActiveRecord
         attrs.each do |attr, value|
           if attr.is_a?(CompositePrimaryKeys::CompositeKeys)
             attr.each_with_index do |key,i|
-              expanded_attrs[key] = value[i]
+              expanded_attrs[key] = value.flatten[i]
             end
           elsif aggregation = reflect_on_aggregation(attr.to_sym)
             mapping = aggregation.mapping

--- a/test/fixtures/reference_type.rb
+++ b/test/fixtures/reference_type.rb
@@ -1,7 +1,8 @@
 class ReferenceType < ActiveRecord::Base
   self.primary_key = :reference_type_id
   has_many :reference_codes, :foreign_key => "reference_type_id", :dependent => :destroy
-  
+  accepts_nested_attributes_for :reference_codes
+
   validates_presence_of :type_label, :abbreviation
   validates_uniqueness_of :type_label
 

--- a/test/test_nested_attributes.rb
+++ b/test/test_nested_attributes.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+# Testing the find action on composite ActiveRecords with two primary keys
+class TestNestedAttributes < ActiveSupport::TestCase
+  fixtures :reference_types
+
+  def setup
+    @reference_type = ReferenceType.first
+  end
+
+  def test_nested_atttribute_create
+    code_id = 1001
+    @reference_type.update_attribute :reference_codes_attributes, [{
+      :reference_code => code_id,
+      :code_label => 'XX',
+      :abbreviation => 'Xx'
+    }]
+    assert_not_nil ReferenceCode.find_by_reference_code(code_id)
+  end
+
+  def test_nested_atttribute_update
+    code_id = 1002
+    @reference_type.update_attribute :reference_codes_attributes, [{
+      :reference_code => code_id,
+      :code_label => 'XX',
+      :abbreviation => 'Xx'
+    }]
+    reference_code = ReferenceCode.find_by_reference_code(code_id)
+    cpk = CompositePrimaryKeys::CompositeKeys[@reference_type.reference_type_id, code_id]
+    @reference_type.update_attribute :reference_codes_attributes, [{
+      :id => cpk,
+      :code_label => 'AAA',
+      :abbreviation => 'Aaa'
+    }]
+    reference_code = ReferenceCode.find_by_reference_code(code_id)
+    assert_kind_of(ReferenceCode, reference_code)
+    assert_equal(reference_code.code_label, 'AAA')
+  end
+end


### PR DESCRIPTION
this fixes an omission in the first patch. Also should fix #141.
Adds a test_nested_attributes test using existing classes.
