### PR TITLE
Patched to AR reverse_sql_order method to brake apart CPKs

### DIFF
--- a/lib/composite_primary_keys/relation/query_methods.rb
+++ b/lib/composite_primary_keys/relation/query_methods.rb
@@ -1,17 +1,27 @@
-module ActiveRecord::QueryMethods
-  alias :original_reverse_sql_order :reverse_sql_order
-end
-
 module CompositePrimaryKeys::ActiveRecord::QueryMethods
 
   def reverse_sql_order(order_query)
-    
+    # CPK
+    # order_query = ["#{quoted_table_name}.#{quoted_primary_key} ASC"] if order_query.empty?
+
     # break apart CPKs 
     order_query = primary_key.map do |key|
       "#{quoted_table_name}.#{connection.quote_column_name(key)} ASC"
     end if order_query.empty?
 
-    original_reverse_sql_order(order_query)
+    order_query.map do |o|
+      case o
+      when Arel::Nodes::Ordering
+        o.reverse
+      when String, Symbol
+        o.to_s.split(',').collect do |s|
+          s.strip!
+          s.gsub!(/\sasc\Z/i, ' DESC') || s.gsub!(/\sdesc\Z/i, ' ASC') || s.concat(' DESC')
+        end
+      else
+        o
+      end
+    end.flatten
   end
 
 end


### PR DESCRIPTION
This is related to #133 which I closed in exchange of this new pull request. Since reverse_order has changed in recent versions of AR you suggested removing the CPK override of that method, which sounds correct. This exposed another issue in ActiveRecord::QueryMethods reverse_sql_order(..) method. The problem in there is it's using the primary_key to build up the sort order. I solved this by creating a reverse_sql_order alias, then overriding the reverse_sql_order where I break apart the CPKs, and then pass that into the original reverse_sql_order method. 
