### PR TITLE
Need to patch AR HasManyAssociation foreign_key_present? method to work with array of keys

### DIFF
--- a/lib/composite_primary_keys/associations/has_many_association.rb
+++ b/lib/composite_primary_keys/associations/has_many_association.rb
@@ -37,6 +37,12 @@ module ActiveRecord
           end
         end
       end
+
+      def foreign_key_present?
+        # CPK
+        # owner.attribute_present?(reflection.association_primary_key)
+        reflection.association_primary_key.all?{ |key| owner.attribute_present?(key) }
+      end
     end
   end
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -269,4 +269,12 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal(1, memberships.length)
     assert_equal([1,1], memberships[0].id)
   end
+
+  def test_foreign_key_present_with_null_association_ids
+    group = Group.new
+    group.memberships.build
+    associations = group.association_cache[:memberships]
+    assert_equal(false, associations.send('foreign_key_present?'))
+  end
+
 end


### PR DESCRIPTION
The ActiveRecord HasManyAssociation foreign_key_present? method needs to be patched to work with a CPK compound key array. Currently this method falsely indicates that a value for the foreign_key exists, which can lead to AR generating unnecessary SELECT statements. The statement generated contain WHERE clause looking for CPK values of NULL (e.g. group_id = NULL).
