### PR TITLE
Allow auto_increment columns to be part of composite key (MySQL only for now)

### DIFF
--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -183,3 +183,12 @@ create table products_restaurants (
   store_id int(11) not null
 ) type=InnoDB;
 
+create table posts (
+  id int(11) not null auto_increment,
+  version int(11) not null default '1',
+  title varchar(255) default null,
+  body text,
+  created_at datetime not null,
+  updated_at datetime not null,
+  primary key  (id, version)
+) type=InnoDB DEFAULT CHARSET=latin1

--- a/test/fixtures/post.rb
+++ b/test/fixtures/post.rb
@@ -1,0 +1,3 @@
+class Post < ActiveRecord::Base
+  set_primary_keys :id, :version
+end

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -87,4 +87,13 @@ class TestCreate < ActiveSupport::TestCase
     assert_equal(25, suburb.suburb_id)
     assert_equal("My Suburb", suburb.name)
   end
+
+  def test_create_auto_increment
+    return unless current_adapter?('MysqlAdapter') ||
+      current_adapter?('Mysql2Adapter')
+    post = Post.new(:title => 'First post', :body => 'Hello world!')
+    assert post.save
+    assert_equal 1, post.version
+    assert_not_nil post[:id], "New post id should be set automatically"
+  end
 end


### PR DESCRIPTION
As I posted in https://groups.google.com/forum/?fromgroups=#!topic/compositekeys/PES6O2B-dWI, creating a composite key that has an auto-increment field as part of it doesn't work as expected. Here's a patch that fixes this on MySQL, with a test case. It's a one-line monkeypatch of ActiveRecord::Persistence#create to assign to self[:id] instead of self.id.

If this line of development is interesting, I can look into fixing it on PostgreSQL and SQLite3 as well.
