### PR TITLE
raise error on destroy when no pk is set

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -13,6 +13,10 @@ module ActiveRecord
         where_hash = {}
         primary_keys = Array(self.class.primary_key)
 
+        if primary_keys.empty?
+          raise ActiveRecord::CompositeKeyError, "No primary key(s) defined for #{self.class.name}"
+        end
+
         #relation = self.class.unscoped.where(
         #  self.class.arel_table[pk].eq(substitute))
 

--- a/test/fixtures/employees_group.rb
+++ b/test/fixtures/employees_group.rb
@@ -1,0 +1,2 @@
+class EmployeesGroup < ActiveRecord::Base
+end

--- a/test/test_delete_without_pk.rb
+++ b/test/test_delete_without_pk.rb
@@ -1,0 +1,20 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestDeleteWithoutPK < ActiveSupport::TestCase
+
+  # can't load fixtures because other test dependencies
+  setup do
+    EmployeesGroup.create(employee_id: 1, group_id: 1)
+    EmployeesGroup.create(employee_id: 1, group_id: 2)
+    EmployeesGroup.create(employee_id: 2, group_id: 1)
+    EmployeesGroup.create(employee_id: 2, group_id: 1)
+  end
+
+  def test_destroy_without_primary_key
+    employees_group = EmployeesGroup.first
+    assert_raise(ActiveRecord::CompositeKeyError) do
+      employees_group.destroy
+    end
+    assert_equal 4, EmployeesGroup.count
+  end
+end

--- a/test/test_suite.rb
+++ b/test/test_suite.rb
@@ -22,6 +22,7 @@ require 'test/unit'
   test_tutorial_example
   test_update
   test_validations
+  test_delete_without_pk
 ).each do |test|
   require File.expand_path("../#{test}", __FILE__)
 end


### PR DESCRIPTION
if you have a model without primary keys set
a model.destroy would cause the whole table to be deleted.
this makes sure that an error is raised in that case
