### PR TITLE
Rails 3.2 - Allow auto_increment columns to be part of composite key (MySQL only for now)

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -5,6 +5,7 @@ module ActiveRecord
   class Base
     INVALID_FOR_COMPOSITE_KEYS = 'Not appropriate for composite primary keys'
     NOT_IMPLEMENTED_YET        = 'Not implemented for composite primary keys yet'
+    class_attribute :auto_increment_column
 
     class << self
       def primary_keys

--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -1,5 +1,20 @@
 module ActiveRecord
   module Persistence
+    def create
+      attributes_values = arel_attributes_values(!id.nil?)
+
+      new_id = self.class.unscoped.insert attributes_values
+
+      # CPK
+      # self.id ||= new_id if self.class.primary_key
+      auto_increment_column = self.class.auto_increment_column || :id
+      self[auto_increment_column] ||= new_id if self.class.primary_key
+
+      IdentityMap.add(self) if IdentityMap.enabled?
+      @new_record = false
+      id
+    end
+
     def destroy
       destroy_associations
 

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -190,3 +190,18 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table document_events (
+    document_event_id int(11) not null auto_increment,
+    to_uid int(11) not null,
+    data text,
+    primary key (to_uid, document_event_id),
+    unique key (document_event_id)
+);
+
+create table widgets (
+    id int(11) not null auto_increment,
+    version int(11) not null default '1',
+    data text,
+    primary key (id, version)
+);

--- a/test/fixtures/document_event.rb
+++ b/test/fixtures/document_event.rb
@@ -1,0 +1,4 @@
+class DocumentEvent < ActiveRecord::Base
+  set_primary_keys :to_uid, :document_event_id
+  self.auto_increment_column = :document_event_id
+end

--- a/test/fixtures/widget.rb
+++ b/test/fixtures/widget.rb
@@ -1,0 +1,3 @@
+class Widget < ActiveRecord::Base
+  set_primary_keys :id, :version
+end

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -109,4 +109,23 @@ class TestCreate < ActiveSupport::TestCase
     assert_equal(25, suburb.suburb_id)
     assert_equal("My Suburb", suburb.name)
   end
+
+  def test_create_auto_increment_with_default_column
+    return unless current_adapter?('MysqlAdapter') || current_adapter?('Mysql2Adapter')
+    widget = Widget.new(:data => "Hello!")
+    assert widget.save
+    assert_equal 1, widget.version
+    assert_not_nil widget.id[0], "New widget id should be set automatically"
+    assert_not_nil widget[:id], "New widget id (hash) should be set automatically"
+  end
+
+  def test_create_auto_increment_with_custom_column
+    return unless current_adapter?('MysqlAdapter') || current_adapter?('Mysql2Adapter')
+    event = DocumentEvent.new(:data => "Hello!", :to_uid => 5)
+    assert event.save
+    assert_equal 5, event.to_uid
+    assert_not_nil event.id[1], "New document event document_event_id should be set automatically"
+    assert_not_nil event[:document_event_id], "New document event document_event_id (hash) should be set automatically"
+  end
+
 end


### PR DESCRIPTION
I saw that a couple months ago in pull request https://github.com/drnic/composite_primary_keys/pull/147, @krbullock made a commit to include this feature for ar_3.0.x, here is the change for 3.2. Additionally I made it so you can customize the auto incrementing column.
