### PR TITLE
Added alias support for primary_keys= to be used as primary_key= 

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -23,9 +23,9 @@ module ActiveRecord
         end
       end
 
-      def primary_keys=(keys)
+      def primary_key_with_composite_key_support=(keys)
         unless keys.kind_of?(Array)
-          self.primary_key = keys
+          self.primary_key_without_composite_key_support = keys
           return
         end
 
@@ -36,6 +36,8 @@ module ActiveRecord
           include CompositeInstanceMethods
         EOV
       end
+      alias_method_chain :primary_key=, :composite_key_support
+      alias_method :primary_keys=, :primary_key=
 
       def set_primary_keys(*keys)
         ActiveSupport::Deprecation.warn(

--- a/test/fixtures/reference_code_using_composite_key_alias.rb
+++ b/test/fixtures/reference_code_using_composite_key_alias.rb
@@ -1,0 +1,8 @@
+class ReferenceCodeUsingCompositeKeyAlias < ActiveRecord::Base
+  self.table_name = 'reference_codes'
+  self.primary_key = [:reference_type_id, :reference_code]
+  
+  belongs_to :reference_type, :foreign_key => "reference_type_id"
+  
+  validates_presence_of :reference_code, :code_label, :abbreviation
+end

--- a/test/fixtures/reference_code_using_simple_key_alias.rb
+++ b/test/fixtures/reference_code_using_simple_key_alias.rb
@@ -1,0 +1,8 @@
+class ReferenceCodeUsingSimpleKeyAlias < ActiveRecord::Base
+  self.table_name = 'reference_codes'
+  self.primary_key = :code_label
+  
+  belongs_to :reference_type, :foreign_key => "reference_type_id"
+  
+  validates_presence_of :reference_code, :code_label, :abbreviation
+end

--- a/test/test_aliases.rb
+++ b/test/test_aliases.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestAliases < ActiveSupport::TestCase
+  fixtures :reference_codes
+
+  def test_primary_key_setter_alias_composite_key
+    reference_code = ReferenceCodeUsingCompositeKeyAlias.find([1, 2])
+    assert_equal 'MRS', reference_code.code_label
+    assert_equal 'Mrs', reference_code.abbreviation
+  end
+
+  def test_primary_key_setter_alias_simple_key
+    reference_code = ReferenceCodeUsingSimpleKeyAlias.find('MRS')
+    assert_equal 1, reference_code.reference_type_id
+    assert_equal 2, reference_code.reference_code
+    assert_equal 'Mrs', reference_code.abbreviation
+  end
+end


### PR DESCRIPTION
A colleague of mine and I encountered a small hick-up using this gem a couple of days ago because we initially mistyped self.primary_keys= as self.primary_key=, and as such, could not pass it an array of columns. It took about 10-15 minutes to notice we needed to type self.primary_keys= to fix. I think this might be a sign that the API has room for improvement given our unconscious thinking that a "composite key" is just a single Rails primary key (not plural according to http://www.techopedia.com/definition/6572/composite-key though has plural columns). Since it is singular, it seemed valid to both of us to contribute a patch that allows self.primary_key= to be used as an alias (alternative option) for self.primary_keys= to better map it to the way developers think about a composite key.

Thanks for providing "composite key" support for ActiveRecord for many years. I have found this gem invaluable in previous projects dealing with legacy databases. I'm surprised the Rails folks haven't incorporated this into Rails directly. I assume it is because of the "convention over configuration" principle. Still, I think this is greatly useful even in modelling new databases. 

Regards,

Andy
