### PR TITLE
Adaptation of overriding of where_values_hash

### DIFF
--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -48,12 +48,12 @@ module ActiveRecord
 
     def add_cpk_where_values_hash
       class << self
-        def where_values_hash
+        def where_values_hash(relation_table_name = table_name)
           # CPK adds this so that it finds the Equality nodes beneath the And node:
           nodes_from_and = with_default_scope.where_values.grep(Arel::Nodes::And).map {|and_node| and_node.children.grep(Arel::Nodes::Equality) }.flatten
 
           equalities = (nodes_from_and + with_default_scope.where_values.grep(Arel::Nodes::Equality)).find_all { |node|
-            node.left.relation.name == table_name
+            node.left.relation.name == relation_table_name
           }
 
           Hash[equalities.map { |where| [where.left.name, where.right] }]


### PR DESCRIPTION
Rails 4.0-stable added a parameter to the method `where_values_hash` (refs https://github.com/composite-primary-keys/composite_primary_keys/issues/185)
