### PR TITLE
Fix exception raised in method "id=" (Rails 4.0.x)

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -80,10 +80,11 @@ module CompositePrimaryKeys
         
         # DB like MySQL doesn't return the newly inserted result.
         # self.id cannot be updated for this case.
-        self.id = new_id if self.class.primary_key and new_id.kind_of?(Array)
+        # self.id.nil? is needed since this function is used for non-composity key too
+        # in this (ar_4.0.x) branch.
+        self.id = new_id if self.class.primary_key and (self.id.nil? or new_id.kind_of?(Array))
 
         @new_record = false
-        
         id
       end
 


### PR DESCRIPTION
Below exception was raised.
lib/composite_primary_keys/composite_arrays.rb:19:in `parse': Unsupported type: 0 (ArgumentError)

It's because new_id 0 was returned in below code.

 74       def create_record(attribute_names = nil)$
 75         record_timestamps!$
 76         attribute_names ||= keys_for_partial_write$
 77         attributes_values = arel_attributes_with_values_for_create(attribute_names)$
 78 
 79         new_id = self.class.unscoped.insert attributes_values$
 80         self.id = new_id if self.class.primary_key$
