### PR TITLE
Fixed issue where 'id_was' would be an array with an array, not an array...

### DIFF
--- a/lib/composite_primary_keys/active_model/dirty.rb
+++ b/lib/composite_primary_keys/active_model/dirty.rb
@@ -4,7 +4,7 @@ module ActiveModel
       # CPK
       if self.composite? && attr == "id"
         self.class.primary_keys.map do |attr|
-          attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)
+          attribute_changed?(attr) ? changed_attributes[attr] : self.ids_hash[attr]
         end
       else
         attribute_changed?(attr) ? changed_attributes[attr] : __send__(attr)


### PR DESCRIPTION
Fixes an issue with the `attribute_was` override. When attempting to update a record, rails calls the `id_was` method. This override resulted in an incorrect value for this, resulting in an invalid query. As an example, with an instance of a model with the foreign keys `[:field_a, :id]`, calling `id_was` results in the array

```
['value in field a', ['value in field a', 1]]
```

The contained array is an instance of the Composite primary key class. This nesting of array causes rails to incorrectly generate a query such as

```
UPDATE "models" SET "field_b" = "value in field b" WHERE("models"."field_a" = "value in field a" AND "models"."id" = "value in field a", 1)
```

This PR solves the issue, by fetching the requested attribute value from the `ids_hash` method instead of simply requesting it directly from the model. In the case where `id` is still used as a primary key, calling `id` on the model returns the composite primary key, not the original `id` value
