### PR TITLE
Fix several issues with the tests

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/read.rb
+++ b/lib/composite_primary_keys/attribute_methods/read.rb
@@ -1,30 +1,6 @@
 module ActiveRecord
   module AttributeMethods
     module Read
-      module ClassMethods
-        def internal_attribute_access_code(attr_name, cast_code)
-          # CPK - this is a really horrid hack, needed to get
-          # right class namespace :(
-          if cast_code.match(/^ActiveRecord/)
-            cast_code = "::#{cast_code}"
-          end
-          access_code = "(v=@attributes[attr_name]) && #{cast_code}"
-
-          # CPK
-          #unless attr_name == primary_key
-          primary_keys = Array(self.primary_key)
-          unless primary_keys.include?(attr_name.to_s)
-            access_code.insert(0, "missing_attribute(attr_name, caller) unless @attributes.has_key?(attr_name); ")
-          end
-
-          if cache_attribute?(attr_name)
-            access_code = "@attributes_cache[attr_name] ||= (#{access_code})"
-          end
-
-          "attr_name = '#{attr_name}'; #{access_code}"
-        end
-      end
-
       rails_read_attribute = instance_method(:read_attribute)
       define_method(:read_attribute) do |attr_name|
         if attr_name.kind_of?(Array)

--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -114,6 +114,7 @@ module ActiveRecord
       end
 
       def ==(comparison_object)
+        return false if !persisted? && comparison_object.object_id != object_id
         return true if equal? comparison_object
         ids.is_a?(Array) ? super(comparison_object) && ids.all? {|id| !id.nil?} : super(comparison_object)
       end

--- a/lib/composite_primary_keys/nested_attributes.rb
+++ b/lib/composite_primary_keys/nested_attributes.rb
@@ -31,7 +31,7 @@ module ActiveRecord
                                eq_predicates = association.klass.primary_key.zip(ids).map do |primary_key, value|
                                  association.klass.arel_table[primary_key].eq(value)
                                end
-                               association.scoped.where(*eq_predicates).to_a
+                               association.scope.where(*eq_predicates).to_a
                              else
                                []
                              end

--- a/test/abstract_unit.rb
+++ b/test/abstract_unit.rb
@@ -3,9 +3,8 @@ PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 # To make debugging easier, test within this source tree versus an installed gem
 $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'composite_primary_keys'
-
-require 'active_support/test_case'
 require 'minitest/autorun'
+require 'active_support/test_case'
 
 # Now load the connection spec
 require File.join(PROJECT_ROOT, "test", "connections", "connection_spec")

--- a/test/test_callbacks.rb
+++ b/test/test_callbacks.rb
@@ -1,54 +1,68 @@
 require File.expand_path('../abstract_unit', __FILE__)
 
-class TestUpdate < ActiveSupport::TestCase
+class TestCallbacks < ActiveSupport::TestCase
   fixtures :suburbs
 
   def setup
     @@callbacks = OpenStruct.new
+
+    Suburb.class_eval do
+      before_create do
+        @@callbacks.before_create = true
+      end
+
+      after_create do
+        @@callbacks.after_create = true
+      end
+
+      around_create do |suburb, block|
+        @@callbacks.around_create = true
+        block.call
+      end
+
+      before_save do
+        @@callbacks.before_save = true
+      end
+
+      after_save do
+        @@callbacks.after_save = true
+      end
+
+      around_save do |suburb, block|
+        @@callbacks.around_save = true
+        block.call
+      end
+
+      before_update do
+        @@callbacks.before_update = true
+      end
+
+      after_update do
+        @@callbacks.after_update = true
+      end
+
+      around_update do |suburb, block|
+        @@callbacks.around_update = true
+        block.call
+      end
+    end
   end
 
-   Suburb.class_eval do
-    before_create do
-      @@callbacks.before_create = true
-    end
-    
-    after_create do
-      @@callbacks.after_create = true
-    end
-    
-    around_create do |suburb, block|
-      @@callbacks.around_create = true
-      block.call
-    end
-
-    before_save do
-      @@callbacks.before_save = true
-    end
-
-    after_save do
-      @@callbacks.after_save = true
-    end
-
-    around_save do |suburb, block|
-      @@callbacks.around_save = true
-      block.call
-    end
-
-    before_update do
-      @@callbacks.before_update = true
-    end
-
-    after_update do
-      @@callbacks.after_update = true
-    end
-
-    around_update do |suburb, block|
-      @@callbacks.around_update = true
-      block.call
-    end
+  def teardown
+    Suburb.reset_callbacks(:create)
+    Suburb.reset_callbacks(:save)
+    Suburb.reset_callbacks(:update)
   end
 
   def test_create
+    refute(@@callbacks.before_save)
+    refute(@@callbacks.after_save)
+    refute(@@callbacks.around_save)
+
+    refute(@@callbacks.before_create)
+    refute(@@callbacks.after_create)
+    refute(@@callbacks.around_create)
+
     suburb = Suburb.new(:city_id => 3, :suburb_id => 3, :name => 'created')
     suburb.save!
 
@@ -62,6 +76,14 @@ class TestUpdate < ActiveSupport::TestCase
   end
 
   def test_update
+    refute(@@callbacks.before_save)
+    refute(@@callbacks.after_save)
+    refute(@@callbacks.around_save)
+
+    refute(@@callbacks.before_create)
+    refute(@@callbacks.after_create)
+    refute(@@callbacks.around_create)
+
     suburb = suburbs(:first)
     suburb.name = 'Updated'
     suburb.save

--- a/test/test_touch.rb
+++ b/test/test_touch.rb
@@ -11,8 +11,8 @@ class TestTouch < ActiveSupport::TestCase
     previously_updated_at = tariff.updated_at
 
     tariff.amount         = previous_amount + 1
+    sleep 1.0 # we need to sleep for 1 second because the times updated (on mysql, at least) are only precise to 1 second.
     tariff.touch
-    sleep 0.1
     assert_not_equal previously_updated_at, tariff.updated_at
     assert_equal previous_amount + 1, tariff.amount
     assert tariff.amount_changed?, 'tarif amount should have changed'


### PR DESCRIPTION
Some tests were failing in certain circumstances (as I mentioned in #209):
1. If `TestCallbacks` is run before other tests that use the `Suburb` model,
    the callbacks are defined but the `@@callbacks` variable they reference
    is not defined.
2. A reference to `scoped` method which no longer exists in ActiveRecord 4.1.
3. For MySQL, the timestamp column is not precise enough to reliably sleep
    for 0.1 second and expect the time to change, so we increase that sleep to
    1.0 second.
4. For MySQL, the default for the PK columns in the `capitols` table come as
    an empty string, which results in CPK thinking
    `Capitol.new == Captiol.new`

As a bonus, this PR also removes some code which never gets run on Rails 4.1.
