### PR TITLE
Deal with to_param CPK IDs in one place. Fixes #209.

### DIFF
--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -177,9 +177,7 @@ module CompositePrimaryKeys
         result = []
         ids.each do |id|
           if id.is_a?(String)
-            if id.index("/")
-              result << id.split("/").map{|subid| subid.split(",") }
-            elsif id.index(",")
+            if id.index(",")
               result << [id.split(",")]
             else
               result << [id]

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -101,21 +101,6 @@ class TestFind < ActiveSupport::TestCase
     assert_equal([1,3], ref_code.id)
   end
 
-  def test_find_some_with_params_ids
-    params_ids = ReferenceCode.find([1,3], [2,1]).to_param
-    assert_equal "1,3/2,1", params_ids
-
-    ref_codes = ReferenceCode.find(params_ids)
-    assert_kind_of(Array, ref_codes)
-    assert_equal(2, ref_codes.length)
-
-    ref_code = ref_codes[0]
-    assert_equal([1,3], ref_code.id)
-
-    ref_code = ref_codes[1]
-    assert_equal([2,1], ref_code.id)
-  end
-
   def test_find_some_with_array_of_params_id
     params_ids = ReferenceCode.find([1,3], [2,1]).map(&:to_param)
     assert_equal ["1,3", "2,1"], params_ids


### PR DESCRIPTION
We parse the IDs in the first line of the finder, and isolate the parsing to one method in case it needs to be used elsewhere (and also so it doesn't make the finder method hard to read).

I added 3 tests to check that the parsing works, and all the other tests still pass (on mysql, postgresql, and sqlite3) so it did not affect the passing in of arrays.

I feel like the code for the parsing could be better, but I'm failing at finding specific ideas to improve it.

Do you seen any deficiencies?
