### PR TITLE
fix ActiveRecord::AttributeMethods::Dirty patch

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/dirty.rb
+++ b/lib/composite_primary_keys/attribute_methods/dirty.rb
@@ -10,14 +10,7 @@ module ActiveRecord
         else
           attr = attr.to_s
 
-          # The attribute already has an unsaved change.
-          if attribute_changed?(attr)
-            old = @changed_attributes[attr]
-            @changed_attributes.delete(attr) unless _field_changed?(attr, old, value)
-          else
-            old = clone_attribute_value(:read_attribute, attr)
-            @changed_attributes[attr] = old if _field_changed?(attr, old, value)
-          end
+          save_changed_attribute(attr, value)
         end
 
         # Carry on.

--- a/test/fixtures/comment.rb
+++ b/test/fixtures/comment.rb
@@ -1,5 +1,7 @@
 class Comment < ActiveRecord::Base
   belongs_to :person, :polymorphic => true
   belongs_to :hack
+
+  enum :shown => [ :true, :false ]
 end
 

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -108,6 +108,7 @@ create table employees (
 create table comments (
     id int not null auto_increment,
     person_id int default null,
+    shown int default null,
     person_type varchar(100) default null,
     hack_id int default null,
     primary key (id)

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -116,6 +116,7 @@ create sequence comments_seq start with 1000;
 create table comments (
     id          number(11)   not null primary key,
     person_id   number(11)   default null,
+    shown       number(11)   default null,
     person_type varchar(100) default null,
     hack_id     number(11)   default null
 );

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -110,6 +110,7 @@ create table employees (
 create table comments (
     id          serial not null,
     person_id   int          default null,
+    shown       int          default null,
     person_type varchar(100) default null,
     hack_id     int          default null,
     primary key (id)

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -101,6 +101,7 @@ create table employees (
 create table comments (
     id integer not null primary key autoincrement,
     person_id int null,
+    shown int null,
     person_type varchar(100) null,
     hack_id int null
 );

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -119,6 +119,7 @@ go
 CREATE TABLE comments (
     id          [int] IDENTITY(1000,1) PRIMARY KEY NOT NULL,
     person_id   [int] NULL,
+    shown       [int] NULL,
     person_type varchar(100)      NULL,
     hack_id     [int] NULL
 );

--- a/test/test_enum.rb
+++ b/test/test_enum.rb
@@ -1,0 +1,20 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestEnum < ActiveSupport::TestCase
+  fixtures :comments
+
+  def test_enum_was
+    comment = Comment.first
+    assert_nil comment.shown
+
+    comment.shown = :true
+    assert_equal 'true', comment.shown
+    assert_nil comment.shown_was
+
+    comment.save
+
+    comment.shown = :false
+    assert_equal 'false', comment.shown
+    assert_equal 'true', comment.shown_was
+  end
+end


### PR DESCRIPTION
was out of date with rails 4.1.4 which was preventing attribute `*_was` fields from being calculated correctly for enum fields.
