### PR TITLE
This fixes a problem for Rails Admin show and edit actions (and posibly for delete).

### DIFF
--- a/lib/composite_primary_keys/sanitization.rb
+++ b/lib/composite_primary_keys/sanitization.rb
@@ -17,6 +17,7 @@ module ActiveRecord
         expanded_attrs = {}
         attrs.each do |attr, value|
           if attr.is_a?(CompositePrimaryKeys::CompositeKeys)
+            value = value.split('/') if value.is_a?(String)
             attr.each_with_index do |key,i|
               expanded_attrs[key] = value.flatten[i]
             end

--- a/test/README_tests.rdoc
+++ b/test/README_tests.rdoc
@@ -47,6 +47,10 @@ directory and run the tests like so:
 
 * ADAPTER=mysql ruby test_equal.rb
 
+Or to run all tests (defined on test_suite.rb):
+
+* ADAPTER=mysql ruby test_suite.rb
+
 == Logging
 
 By default, ActiveRecord's log messages are sent to standard out when


### PR DESCRIPTION
This is done by turning the primary keys attributes from a string to an array by splitting on '/' (used on Rails Admin routes).
