### PR TITLE
Implement id_was for rails 4.1.6 compatibility

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -111,6 +111,10 @@ module ActiveRecord
         id
       end
 
+      def id_was
+        attribute_was("id")
+      end
+
       def ==(comparison_object)
         return false if !persisted? && comparison_object.object_id != object_id
         return true if equal? comparison_object


### PR DESCRIPTION
An `id_was` method has been added which, in the default version, passes the name of the primary key attribute to `attribute_was` but when CPK is in use that winds up passing a flattened string of the list of keys, which CPK's custom `attribute_was` doesn't recognise and handle.
