### PR TITLE
fixes failing require and postgres and sqlite3 test delete_all test

### DIFF
--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -68,7 +68,6 @@ require 'active_record/relation/query_methods'
 require 'active_record/validations/uniqueness'
 
 # CPK files
-require 'composite_primary_keys/active_model/dirty'
 require 'composite_primary_keys/persistence'
 require 'composite_primary_keys/base'
 require 'composite_primary_keys/core'

--- a/test/test_delete_all.rb
+++ b/test/test_delete_all.rb
@@ -13,10 +13,9 @@ class TestValidations < ActiveSupport::TestCase
     EmployeesGroup.create(employee_id: 3, group_id: 103)
 
     assert_equal(EmployeesGroup.all.size, 3)
-    exception = assert_raises(ActiveRecord::StatementInvalid) {
+    assert_raises(ActiveRecord::StatementInvalid) {
       EmployeesGroup.where(employee_id: 1).first.destroy
     }
-    assert_match(/Unknown column 'employees_groups.' in 'where clause/, exception.message)
     assert(EmployeesGroup.all.size == 3)
   end
 end


### PR DESCRIPTION
**CHANGES:**
- this file composite_primary_keys/active_model/dirty does not exist
- Checking the line exception message is not really ideal as it will
  depend on each drivers' implementation
