### PR TITLE
fixed active_model/dirty (LoadError)

### DIFF
--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -68,7 +68,6 @@ require 'active_record/relation/query_methods'
 require 'active_record/validations/uniqueness'
 
 # CPK files
-require 'composite_primary_keys/active_model/dirty'
 require 'composite_primary_keys/persistence'
 require 'composite_primary_keys/base'
 require 'composite_primary_keys/core'


### PR DESCRIPTION
https://github.com/composite-primary-keys/composite_primary_keys/commit/c9d02647754cc403e5f35dbe54ed5f36507811bc
this commit remove active_model/dirty.rb but require 'active_model/dirty'
