### PR TITLE
Remove singleton classes on CPK relations against Rails 4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem "activerecord", rails_version
 
 gem "mysql2"
 gem 'sqlite3'
+gemspec

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency('activerecord', '=4.1.6')
+  s.add_development_dependency('rake', '~> 10.3.2')
 end

--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -107,3 +107,5 @@ require 'composite_primary_keys/relation/predicate_builder'
 require 'composite_primary_keys/relation/query_methods'
 
 require 'composite_primary_keys/validations/uniqueness'
+
+require 'composite_primary_keys/composite_relation'

--- a/lib/composite_primary_keys/composite_relation.rb
+++ b/lib/composite_primary_keys/composite_relation.rb
@@ -1,0 +1,44 @@
+module CompositePrimaryKeys
+  module CompositeRelation
+    include CompositePrimaryKeys::ActiveRecord::Batches
+    include CompositePrimaryKeys::ActiveRecord::Calculations
+    include CompositePrimaryKeys::ActiveRecord::FinderMethods
+    include CompositePrimaryKeys::ActiveRecord::QueryMethods
+
+    def delete(id_or_array)
+      # Without CPK:
+      # where(primary_key => id_or_array).delete_all
+
+      id_or_array = if id_or_array.kind_of?(CompositePrimaryKeys::CompositeKeys)
+        [id_or_array]
+      else
+        Array(id_or_array)
+      end
+
+      id_or_array.each do |id|
+        where(cpk_id_predicate(table, self.primary_key, id)).delete_all
+      end
+    end
+
+    def destroy(id_or_array)
+      # Without CPK:
+      #if id.is_a?(Array)
+      #  id.map { |one_id| destroy(one_id) }
+      #else
+      #  find(id).destroy
+      #end
+
+      id_or_array = if id_or_array.kind_of?(CompositePrimaryKeys::CompositeKeys)
+        [id_or_array]
+      else
+        Array(id_or_array)
+      end
+
+      id_or_array.each do |id|
+        where(cpk_id_predicate(table, self.primary_key, id)).each do |record|
+          record.destroy
+        end
+      end
+    end
+  end
+end

--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -4,7 +4,6 @@ module ActiveRecord
     def initialize(klass, table, values = {})
       initialize_without_cpk(klass, table, values)
       add_cpk_support if klass && klass.composite?
-      add_cpk_where_values_hash
     end
 
     alias :initialize_copy_without_cpk :initialize_copy
@@ -14,71 +13,27 @@ module ActiveRecord
     end
 
     def add_cpk_support
-      class << self
-        include CompositePrimaryKeys::ActiveRecord::Batches
-        include CompositePrimaryKeys::ActiveRecord::Calculations
-        include CompositePrimaryKeys::ActiveRecord::FinderMethods
-        include CompositePrimaryKeys::ActiveRecord::QueryMethods
-
-        def delete(id_or_array)
-          # Without CPK:
-          # where(primary_key => id_or_array).delete_all
-
-          id_or_array = if id_or_array.kind_of?(CompositePrimaryKeys::CompositeKeys)
-            [id_or_array]
-          else
-            Array(id_or_array)
-          end
-
-          id_or_array.each do |id|
-            where(cpk_id_predicate(table, self.primary_key, id)).delete_all
-          end
-        end
-
-        def destroy(id_or_array)
-          # Without CPK:
-          #if id.is_a?(Array)
-          #  id.map { |one_id| destroy(one_id) }
-          #else
-          #  find(id).destroy
-          #end
-
-          id_or_array = if id_or_array.kind_of?(CompositePrimaryKeys::CompositeKeys)
-            [id_or_array]
-          else
-            Array(id_or_array)
-          end
-
-          id_or_array.each do |id|
-            where(cpk_id_predicate(table, self.primary_key, id)).each do |record|
-              record.destroy
-            end
-          end
-        end
-      end
+      extend CompositePrimaryKeys::CompositeRelation
     end
 
-    def add_cpk_where_values_hash
-      class << self
-        def where_values_hash(relation_table_name = table_name)
-          # CPK adds this so that it finds the Equality nodes beneath the And node:
-          #equalities = where_values.grep(Arel::Nodes::Equality).find_all { |node|
-          #  node.left.relation.name == table_name
-          # }
-          nodes_from_and = where_values.grep(Arel::Nodes::And).map {|and_node| and_node.children.grep(Arel::Nodes::Equality) }.flatten
+    # CPK adds this so that it finds the Equality nodes beneath the And node:
+    # equalities = where_values.grep(Arel::Nodes::Equality).find_all { |node|
+    #  node.left.relation.name == table_name
+    # }
+    alias :where_values_hash_without_cpk :where_values_hash
+    def where_values_hash(relation_table_name = table_name)
+      nodes_from_and = where_values.grep(Arel::Nodes::And).map {|and_node| and_node.children.grep(Arel::Nodes::Equality) }.flatten
 
-          equalities = (nodes_from_and + where_values.grep(Arel::Nodes::Equality)).find_all { |node|
-            node.left.relation.name == relation_table_name
-          }
+      equalities = (nodes_from_and + where_values.grep(Arel::Nodes::Equality)).find_all { |node|
+        node.left.relation.name == relation_table_name
+      }
 
-          binds = Hash[bind_values.find_all(&:first).map { |column, v| [column.name, v] }]
+      binds = Hash[bind_values.find_all(&:first).map { |column, v| [column.name, v] }]
 
-          Hash[equalities.map { |where|
-            name = where.left.name
-            [name, binds.fetch(name.to_s) { where.right }]
-          }]
-        end
-      end
+      Hash[equalities.map { |where|
+        name = where.left.name
+        [name, binds.fetch(name.to_s) { where.right }]
+      }]
     end
 
     def _update_record(values, id, id_was)

--- a/test/test_dumpable.rb
+++ b/test/test_dumpable.rb
@@ -1,0 +1,15 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestDumpable < ActiveSupport::TestCase
+  fixtures :articles, :readings, :users
+
+  def test_marshal_with_simple_preload
+    articles = Article.preload(:readings).where(id: 1).to_a
+    assert_equal(Marshal.load(Marshal.dump(articles)), articles)
+  end
+
+  def test_marshal_with_comples_preload
+    articles = Article.preload({ readings: :user }).where(id: 1).to_a
+    assert_equal(Marshal.load(Marshal.dump(articles)), articles)
+  end
+end


### PR DESCRIPTION
This is similar to #239 but targets AR 4.1 instead of 4.0.

[We Heart It](weheartit.com) is using #239 in production right now and everything is Ok for us.

We're having the same `Marshal` problems on the Rails 4.1 update, so I'm submitting the "same" PR for 4.1.

I can cherry-pick the callback tests added on #239 once they get merged & accepted.
