### PR TITLE
Update for rails 4.1.7

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 1.9.3'
-  s.add_dependency('activerecord', '=4.1.6')
+  s.add_dependency('activerecord', '=4.1.7')
 end

--- a/lib/composite_primary_keys/version.rb
+++ b/lib/composite_primary_keys/version.rb
@@ -2,7 +2,7 @@ module CompositePrimaryKeys
   module VERSION
     MAJOR = 7
     MINOR = 0
-    TINY  = 11
+    TINY  = 12
     STRING = [MAJOR, MINOR, TINY].join('.')
   end
 end


### PR DESCRIPTION
As best I can tell both the sqlite3 and postgresql tests have the same failures with 4.1.6 and 4.1.7 and all the openstreetmap tests pass so this just bumps the version and the dependency.
