### PR TITLE
Fixes the no method error for ensure_initialized

### DIFF
--- a/lib/composite_primary_keys/core.rb
+++ b/lib/composite_primary_keys/core.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     def init_internals
       # CPK
       # @attributes.ensure_initialized(self.class.primary_key)
-      Array(self.class.primary_key).each {|key| @attributes.ensure_initialized(key)}
+      Array(self.class.primary_key).each {|key| self[key] = nil unless self.attributes.key?(key)}
 
       @aggregation_cache        = {}
       @association_cache        = {}


### PR DESCRIPTION
`ensure_initialized` method exists up to 4.2.0.beta4, but removed in 4.2.0.rc1, see: https://www.omniref.com/ruby/gems/activerecord/4.2.0.rc1/files/lib/active_record/attribute_set.rb#tab=Q---A

Fixed code in the same format as previous versions not using `ensure_initialized`