### PR TITLE
Updates to use Rails 4.2.0 final (as opposed to release candidates)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-rails_version = ENV["RAILS_VERSION"] || "~>4.2.0.rc2"
+rails_version = ENV["RAILS_VERSION"] || "~>4.2.0"
 
 gem "activerecord", rails_version
 

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('activerecord', '~>4.2.0.rc2')
+  s.add_dependency('activerecord', '~>4.2.0')
   s.add_development_dependency('rake', '~> 10.3.2')
 end

--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -26,7 +26,7 @@ $:.unshift(File.dirname(__FILE__)) unless
 
 unless defined?(ActiveRecord)
   require 'rubygems'
-  gem 'activerecord', '4.2.0.rc2'
+  gem 'activerecord', '4.2.0'
   require 'active_record'
 end
 


### PR DESCRIPTION
Nothing changes except the dependency on the release candidates to the final released version.
