### PR TITLE
README change to convey finding available versions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,6 +25,10 @@ things straight, here is the mapping:
     Version 5.x is designed to work with ActiveRecord 3.2.x
     Version 4.x is designed to work with ActiveRecord 3.1.x
 
+Run the following command to list available versions:
+
+    gem list composite_primary_keys -ra
+
 == The basics
 
 A model with composite primary keys is defined like this:


### PR DESCRIPTION
The README says to specific a specific version in the Gemfile but then lists "6.x" and doesn't spell out what versions are available in the 6.x area.  I added a small blurb on how to display all available versions.