### PR TITLE
Fix habtm association #delete_records

### DIFF
--- a/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
+++ b/lib/composite_primary_keys/associations/has_and_belongs_to_many_association.rb
@@ -49,7 +49,8 @@ module ActiveRecord
 
           predicate1 = cpk_id_predicate(relation, Array(reflection.foreign_key), Array(owner.id))
           predicate2 = cpk_in_predicate(relation, Array(reflection.association_foreign_key), records.map { |x| x.id }) unless records == :all
-          stmt = relation.where(predicate1.and(predicate2)).compile_delete
+          conds = predicate2.nil?? predicate1 : predicate1.and(predicate2)
+          stmt = relation.where(conds).compile_delete
 
           owner.class.connection.delete stmt.to_sql
         end

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -90,11 +90,13 @@ class TestDelete < ActiveSupport::TestCase
   end
   
   def test_destroy_has_and_belongs_to_many_on_non_cpk
-    steve = employees(:steve)
     records_before = ActiveRecord::Base.connection.execute("select * from employees_groups").count
-    steve.destroy
+    employee = Employee.create
+    employee.groups << Group.create(name: 'test')
+    employees_groups_count = employee.groups.count
+    employee.destroy!
     records_after = ActiveRecord::Base.connection.execute("select * from employees_groups").count
-    assert_equal records_after, records_before - steve.groups.count
+    assert_equal records_before, records_after
   end
 
   def test_delete_not_destroy_on_cpk


### PR DESCRIPTION
Fixes #273 - habtm association issue when destroying a record.

Let say we have a Foo record that has-and-belongs-to-many Bar records. When we destroy Foo record, the association data in the junction table bars_foos doesn't get deleted. On closer inspection this happens because of the invalid delete statement which silently fails, e.g.:
```
  DELETE FROM `bars_foos` WHERE `bars_foos`.`foo_id` = 1 AND NULL
```

This commit amends the habtm test to fail and demonstrate this bug.

Then it addresses this bug inside the HasAndBelongsToManyAssociation in the #delete_records. It makes sure only non-empty predicates are used when scoping the to-be-removed records of the junction table.

Consequently a valid delete statement is generated and test passes.