### PR TITLE
Skip query cache for polymorphic associations.

### DIFF
--- a/lib/composite_primary_keys/associations/singular_association.rb
+++ b/lib/composite_primary_keys/associations/singular_association.rb
@@ -3,7 +3,8 @@ module CompositePrimaryKeys
     extend ActiveSupport::Concern
     included do
       def get_records_with_cpk_support
-        cpk_applies = (target && target.composite?) || (owner && owner.composite?)
+        cpk_applies = (target && target.composite?) || (owner && owner.composite?) ||
+          reflection.foreign_key.is_a?(Array)
         return scope.limit(1).to_a if cpk_applies
         get_records_without_cpk_support
       end


### PR DESCRIPTION
As of 826ae7ac580a6616d7b777bece4db37ac606a816 we seem to be correctly bypassing the AdequateRecord query cache for cpk queries.  However, we don't seem to catch polymorphic associations.  This patch catches polymorphic associations by checking if the association's foreign key is an Array instead of symbol.  
