### PR TITLE
Fixed merging database config when DATABASE_URL is set

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
     end
 
-    def self.establish_connection(spec = ENV["DATABASE_URL"])
+    def self.establish_connection(spec = nil)
       spec     ||= ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym
       resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
       spec     =   resolver.spec(spec)


### PR DESCRIPTION
The `establish_connection` [monkey patch](https://github.com/composite-primary-keys/composite_primary_keys/blob/master/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb#L12) breaks the enhancements introduced in rails  [PR 13463](
https://github.com/rails/rails/pull/13463).

When `DATABASE_URL` is present, the current code ignores additional parameters specified in the database.yml. The fix makes the method signature in the monkey patch similar to the [signature in the rails code](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_handling.rb#L47)
 