### PR TITLE
Case insensitive key compares in the preloader.

### DIFF
--- a/lib/composite_primary_keys/associations/preloader/association.rb
+++ b/lib/composite_primary_keys/associations/preloader/association.rb
@@ -64,7 +64,7 @@ module ActiveRecord
             # }
             @preloaded_records.map { |record|
               key = Array(association_key_name).map do |key_name|
-                record[key_name]
+                record[key_name].to_s.downcase
               end.join(CompositePrimaryKeys::ID_SEP)
 
               [record, key]
@@ -77,7 +77,7 @@ module ActiveRecord
                                    # CPK
                                    # owner[owner_key_name].to_s
                                    Array(owner_key_name).map do |key_name|
-                                     owner[key_name]
+                                     owner[key_name].to_s.downcase
                                    end.join(CompositePrimaryKeys::ID_SEP)
                                  end
                                else
@@ -85,7 +85,7 @@ module ActiveRecord
                                    # CPK
                                    # owner[owner_key_name]
                                    Array(owner_key_name).map do |key_name|
-                                     owner[key_name]
+                                     owner[key_name].to_s.downcase
                                    end.join(CompositePrimaryKeys::ID_SEP)
                                  end
                                end


### PR DESCRIPTION
It so happened that some of my data has differing cases for some of my keys.  I know this would be considered bad practice, but it is actually data synced from a client's database which is managed by a program that is not affiliated with my company in any way, so we have no control.  

It's for animals.  There is a `species` table with a string primary key, and they store it in all caps (Ex: CANINE, FELINE, etc).  It shows up in the `animals` table in all lower case (Ex: canine, feline, etc).  During a join between those two tables MySql is perfectly happy because it does all its compares case insensitive (as do most databases by default).  However, when preloading relations, CPK crashes.  

This isn't something that ActiveRecord handles correctly either, so I thought about submitting this change there, but Rails expects all of their primary keys to be integers, so they shouldn't have this problem.  However, composite keys are often necessary because you don't have a surrogate, auto-incrementing primary key.  In our case we have a composite key with a client identifier (to partition the data based on the client we synced it from), along with the string based primary key from their database.  So CPK has to deal with string keys quite frequently, while ActiveRecord never expects to.  

This patch simply downcases all keys in the preloader to get a case insensitive compare, which matches MYSQL database queries.  I wouldn't mind trying to figure out which database adapter is being used, to see if we should do case-sensitive or case-insensitive matches, but I don't know how to get that info.  If someone else does and wants to tell me how or add it themselves, that would be great. 
