### PR TITLE
Chore/ar 3.2.x: baseline testing: allow nil in parts of composite primary key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ db
 *.swp
 
 test/connections/databases.yml
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ language: ruby
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake sqlite3:build_database postgresql:build_database mysql:build_database
+  - rake sqlite3:build_database postgresql:build_database
 
 script:
-  - rake sqlite3:test
-  - rake postgresql:test
-  - rake mysql:test
+  - "rake sqlite3:test"
+  - "rake postgresql:test"
 
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+
+before_script:
+  - cp test/connections/databases.ci.yml test/connections/databases.yml
+  - rake sqlite3:build_database postgresql:build_database mysql:build_database
+
+script:
+  - rake sqlite3:test
+  - rake postgresql:test
+  - rake mysql:test
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+
+env:
+  CPK_LOGFILE: test.log

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,5 +26,9 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 1.8.7'
-  s.add_dependency('activerecord', '>= 3.2.9', '~> 3.2.0')
+  s.add_dependency('activerecord', '~> 3.2.9')
+
+  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('pg')
+  s.add_development_dependency('mysql2')
 end

--- a/test/connections/databases.ci.yml
+++ b/test/connections/databases.ci.yml
@@ -1,0 +1,15 @@
+mysql:
+  adapter: mysql2
+  username: travis
+  password: ""
+  database: composite_primary_keys_unittest
+
+sqlite3:
+  adapter: sqlite3
+  database: db/composite_primary_keys_unittest.sqlite
+
+postgresql:
+  adapter: postgresql
+  database: composite_primary_keys_unittest
+  username: postgres
+  host: localhost

--- a/test/fixtures/db_definitions/db2-create-tables.sql
+++ b/test/fixtures/db_definitions/db2-create-tables.sql
@@ -109,3 +109,9 @@ create table products_restaurants (
   franchise_id integer not null,
   store_id integer not null
 );
+
+create table mittens (
+  left_id INTEGER,
+  right_id INTEGER NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -190,3 +190,9 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table mittens (
+  left_id INTEGER,
+  right_id INTEGER NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -205,3 +205,9 @@ create table employees_groups (
   group_id int not null
 );
 
+create table mittens (
+  left_id number(11),
+  right_id number(11) NOT NULL,
+  name varchar(50) NOT NULL,
+  primary key (left_id, right_id)
+);

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -192,3 +192,9 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table mittens (
+  left_id int,
+  right_id int NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -179,3 +179,8 @@ create table employees_groups (
   group_id integer not null
 );
 
+create table mittens (
+  left_id int(11),
+  right_id int(11) not null,
+  name varchar(50) not null
+);

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -208,3 +208,10 @@ CREATE TABLE products_restaurants (
     store_id     [int] NOT NULL
 );
 go
+
+CREATE TABLE mittens (
+    left_id  [int],
+    right_id [int]         NOT NULL,
+    name     [varchar](50) NOT NULL
+);
+go

--- a/test/fixtures/mitten.rb
+++ b/test/fixtures/mitten.rb
@@ -1,0 +1,3 @@
+class Mitten < ActiveRecord::Base
+  self.primary_keys = [:left_id, :right_id]
+end

--- a/test/fixtures/mittens.yml
+++ b/test/fixtures/mittens.yml
@@ -1,0 +1,9 @@
+red_pair:
+  left_id: 1
+  right_id: 2
+  name: The red ones
+
+blue_pair:
+  left_id: NULL
+  right_id: 3
+  name: The blue ones

--- a/test/test_equal.rb
+++ b/test/test_equal.rb
@@ -4,6 +4,10 @@ class TestEqual < ActiveSupport::TestCase
   fixtures :capitols
 
   def test_new
+    assert_nil(Capitol.new.to_param)
+    assert_equal([nil, nil], Capitol.new.ids)
+    refute(Capitol.new.equal?(Capitol.new))
+    refute(Capitol.new == Capitol.new)
     assert_not_equal(Capitol.new, Capitol.new)
   end
 

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -97,4 +97,18 @@ class TestFind < ActiveSupport::TestCase
       assert_equal(Department.count, batch.size)
     end
   end
+
+  fixtures :mittens
+
+  def test_find_one_with_nil_as_part_of_id
+    fully_defined = mittens(:red_pair)
+    assert_equal("1,2", fully_defined.to_param)
+
+    somewhat_lacking = mittens(:blue_pair)
+    assert_equal(",3", somewhat_lacking.to_param)
+    assert_equal([nil, 3], somewhat_lacking.to_key)
+
+    assert_equal('The red ones', Mitten.find([1,2]).name)
+    assert_equal('The blue ones', Mitten.find([nil, 3]).name)
+  end
 end

--- a/test/test_touch.rb
+++ b/test/test_touch.rb
@@ -12,7 +12,7 @@ class TestTouch < ActiveSupport::TestCase
 
     tariff.amount         = previous_amount + 1
     tariff.touch
-    sleep 0.1
+    sleep 1
     assert_not_equal previously_updated_at, tariff.updated_at
     assert_equal previous_amount + 1, tariff.amount
     assert tariff.amount_changed?, 'tarif amount should have changed'


### PR DESCRIPTION
I'm on a bit of a quest here with #306, so I thought I'd establish a proper test of the functionality in the AR 3.2 supporting version of the gem.

As a bonus I include a working Travis CI setup, ready for enabling, should you wish to do so. I can also make a PR without anything but the `mittens` stuff. 

What do you all think?
