### PR TITLE
AR 4.2.x support compound keys with nil

### DIFF
--- a/test/fixtures/db_definitions/db2-create-tables.sql
+++ b/test/fixtures/db_definitions/db2-create-tables.sql
@@ -124,3 +124,9 @@ create table products_restaurants (
   franchise_id integer not null,
   store_id integer not null
 );
+
+create table mittens (
+  left_id INTEGER,
+  right_id INTEGER NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -216,3 +216,9 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table mittens (
+  left_id INTEGER,
+  right_id INTEGER NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -221,3 +221,9 @@ create table employees_groups (
   group_id int not null
 );
 
+create table mittens (
+  left_id number(11),
+  right_id number(11) NOT NULL,
+  name varchar(50) NOT NULL,
+  primary key (left_id, right_id)
+);

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -218,3 +218,9 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table mittens (
+  left_id int,
+  right_id int NOT NULL,
+  name varchar(50) NOT NULL
+);

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -204,3 +204,8 @@ create table employees_groups (
   group_id integer not null
 );
 
+create table mittens (
+  left_id int(11),
+  right_id int(11) not null,
+  name varchar(50) not null
+);

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -224,3 +224,10 @@ CREATE TABLE products_restaurants (
     store_id     [int] NOT NULL
 );
 go
+
+CREATE TABLE mittens (
+    left_id  [int],
+    right_id [int]         NOT NULL,
+    name     [varchar](50) NOT NULL
+);
+go

--- a/test/fixtures/mitten.rb
+++ b/test/fixtures/mitten.rb
@@ -1,0 +1,3 @@
+class Mitten < ActiveRecord::Base
+  self.primary_keys = [:left_id, :right_id]
+end

--- a/test/fixtures/mittens.yml
+++ b/test/fixtures/mittens.yml
@@ -1,0 +1,9 @@
+red_pair:
+  left_id: 1
+  right_id: 2
+  name: The red ones
+
+blue_pair:
+  left_id: NULL
+  right_id: 3
+  name: The blue ones

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -116,4 +116,18 @@ class TestFind < ActiveSupport::TestCase
     ref_code = ref_codes[1]
     assert_equal([2,1], ref_code.id)
   end
+
+  fixtures :mittens
+
+  def test_find_one_with_nil_as_part_of_id
+    fully_defined = mittens(:red_pair)
+    assert_equal("1,2", fully_defined.to_param)
+
+    somewhat_lacking = mittens(:blue_pair)
+    assert_equal(",3", somewhat_lacking.to_param)
+    assert_equal([nil, 3], somewhat_lacking.to_key)
+
+    assert_equal('The red ones', Mitten.find([1,2]).name)
+    assert_equal('The blue ones', Mitten.find([nil, 3]).name)
+  end
 end


### PR DESCRIPTION
This is based on #310 (establish green CI). It introduces a test to ensure `nil` is a valid value in a compound foreign key. For now this is just a failing test, as this has been broken since ActiveRecord 4.1 (worked fine in ActiveRecord 3.2.x and 4.0.x). 

Other related pull-requests and issues:
- #306 - original issue where I documented the changed behaviour
- #309 - prove it works in ActiveRecord 3.2
- #307 - a similar patch-set for ActiveRecord 4.1 with a failing test

Sorry for all the noise and issues and pull-requests with various bases, but I'd love for help to resolve this, if anybody has any idea where to start fixing the code. For now we have a failing test-case demonstrating the issue (45e4bb, which passes in gem-versions supporting ActiveRecord 3.2 and 4.0). 

I promise there will be cake :cake: 
