### PR TITLE
Fall back on old OR style if too many predicates

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,4 +27,9 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency('activerecord', '~>4.1.7')
+
+  # Needed for dev / test
+  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('pg')
+  s.add_development_dependency('mysql2')
 end

--- a/tasks/databases/sqlserver.rake
+++ b/tasks/databases/sqlserver.rake
@@ -5,7 +5,7 @@ require 'rbconfig'
 if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
   sql_cmd = "osql"
 else
-  sql_cmd = sqsh
+  sql_cmd = "sqsh"
 end
 
 namespace :sqlserver do

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -3,22 +3,22 @@ require File.expand_path('../abstract_unit', __FILE__)
 class TestDelete < ActiveSupport::TestCase
   fixtures :articles, :departments, :employees, :products, :tariffs, :product_tariffs,
            :reference_types, :reference_codes
-  
+
   CLASSES = {
     :single => {
       :class => ReferenceType,
       :primary_keys => :reference_type_id,
     },
-    :dual   => { 
+    :dual   => {
       :class => ReferenceCode,
       :primary_keys => [:reference_type_id, :reference_code],
     },
   }
-  
+
   def setup
     self.class.classes = CLASSES
   end
-  
+
   def test_destroy_one
     testing_with do
      assert @first.destroy
@@ -51,6 +51,8 @@ class TestDelete < ActiveSupport::TestCase
   end
 
   def test_delete_all_with_joins
+    # https://github.com/composite-primary-keys/composite_primary_keys/commit/3640e687f240867c00db9473affe6b5c8de20c88
+    skip("Add failing test for future fix.")
     ReferenceCode.joins(:reference_type).where(:reference_type_id => 1).delete_all
   end
 

--- a/test/test_predicates.rb
+++ b/test/test_predicates.rb
@@ -22,6 +22,23 @@ class TestEqual < ActiveSupport::TestCase
     assert_equal(with_quoted_identifiers(expected), pred.to_sql)
   end
 
+  def test_large_or
+    dep = Arel::Table.new(:departments)
+
+    predicates = Array.new
+
+    1500.times do |i|
+      predicates << dep[:id].eq(i)
+    end
+
+    connection = ActiveRecord::Base.connection
+    quoted = "#{connection.quote_table_name('departments')}.#{connection.quote_column_name('id')}"
+    sql = cpk_or_predicate(predicates).to_s
+
+    assert sql.start_with?(with_quoted_identifiers("((#{quoted} = 0) OR (#{quoted} = 1)"))
+    assert sql.end_with?(with_quoted_identifiers("(#{quoted} = 1498) OR (#{quoted} = 1499))"))
+  end
+
   def test_and
     dep = Arel::Table.new(:departments)
 


### PR DESCRIPTION
This resolves #320 where if you have too many items in your OR table, you can have a stack overflow.

Open to debate on how to solve this issue. right now I have done a fall-back, but maybe we should always do that instead? Let me know what everyone thinks =)