### PR TITLE
ConnectionNotEstablished error when db connection is on class other than ActiveRecord::Base

### DIFF
--- a/lib/composite_primary_keys/relation/calculations.rb
+++ b/lib/composite_primary_keys/relation/calculations.rb
@@ -18,7 +18,6 @@ module CompositePrimaryKeys
         # Postgresql doesn't like ORDER BY when there are no GROUP BY
         relation = reorder(nil)
 
-        column_alias = column_name
         # CPK
         #if operation == "count" && (relation.limit_value || relation.offset_value)
         if operation == "count"
@@ -29,7 +28,6 @@ module CompositePrimaryKeys
         else
           column = aggregate_column(column_name)
 
-          column_alias = select_value.alias
           select_value = operation_over_aggregate_column(column, operation, distinct)
 
           relation.select_values = [select_value]

--- a/lib/composite_primary_keys/relation/calculations.rb
+++ b/lib/composite_primary_keys/relation/calculations.rb
@@ -18,6 +18,7 @@ module CompositePrimaryKeys
         # Postgresql doesn't like ORDER BY when there are no GROUP BY
         relation = reorder(nil)
 
+        column_alias = column_name
         # CPK
         #if operation == "count" && (relation.limit_value || relation.offset_value)
         if operation == "count"
@@ -28,6 +29,7 @@ module CompositePrimaryKeys
         else
           column = aggregate_column(column_name)
 
+          column_alias = select_value.alias
           select_value = operation_over_aggregate_column(column, operation, distinct)
 
           relation.select_values = [select_value]
@@ -35,7 +37,11 @@ module CompositePrimaryKeys
           query_builder = relation.arel
         end
 
-        type_cast_calculated_value(@klass.connection.select_value(query_builder.to_sql), column_for(column_name), operation)
+        result = @klass.connection.select_all(query_builder, nil, relation.bind_values)
+        row    = result.first
+        value  = row && row.values.first
+
+        type_cast_calculated_value(value, column_for(column_name), operation)
       end
 
       def build_count_subquery(relation, column_name, distinct)


### PR DESCRIPTION
Similar to #283, this pull request fixes `ConnectionNotEstablished` errors when the database connection has been established on a class other than `ActiveRecord::Base`.  The explanation of the use case is the exact same as #283.  I ran into the bug when trying to run `Model.find_each` as opposed to `Model.count` as @wconrad describes.

The merge @wconrad provided was against ActiveRecord 4.1, whereas this one targets ActiveRecord 3.2.  One minor change is that `result.column_types.fetch(column_alias)` threw an undefined method error, so I reverted back to using `column_for(column_name)` as the code did originally.

Since the code is practically the same as the accepted merge of #284, I have not tested it beyond verifying that `Model.find_each` and `Model.count` works correctly.
