### PR TITLE
When using .create with a sequence column, have the proper ID come back instead of nil.

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -1,5 +1,20 @@
 module ActiveRecord
   module Persistence
+    def _create_record(attribute_names = self.attribute_names)
+      attributes_values = arel_attributes_with_values_for_create(attribute_names)
+
+      new_id = self.class.unscoped.insert attributes_values
+
+      # CPK
+      # If one of the key columns is set up in a Postgres database with a SEQUENCE or MySQL with AUTO_INCREMENT,
+      # then because of memoization that attribute comes back as nil instead of reporting its new integer value.
+      #self.id ||= new_id if self.class.primary_key
+      self.id = new_id if self.class.primary_key
+
+      @new_record = false
+      id
+    end
+
     def relation_for_destroy
       # CPK
       if self.composite?


### PR DESCRIPTION
I'm using CPK with Rails 4.2.1 to make Type II tables that use a start_datetime and end_datetime.  The primary key is a composite of ID and start_datetime.  Because with CPK the rails "id" is now mapped to the array of key attributes, and in many cases I still want to directly reference the integer ID number, I ditched the normal sequenced ID built by a rails migration by using "id: false".  I then created an xid column that has a Postgres sequence (in other RDBMS it's AUTO_INCREMENT / identity, etc).  So I can refer to the composite key with "id", or just the integer part with "xid".  When calling .create this was coming back with nil for the xid unless I take off memoization, as you see on line 12.

Apparently this is breaking habtm though.  Will dig in and see why this is happening and get back to this a bit later.
