### PR TITLE
Bug Fix: wrong database syntax when using inheritance 

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -20,7 +20,7 @@ module ActiveRecord
           where_hash[key.to_s] = self[key]
         end
 
-        # CPK      
+        # CPK
         #relation.bind_values = [[column, id]]
 
         relation = self.class.unscoped.where(where_hash)
@@ -76,7 +76,7 @@ module ActiveRecord
           stmt = klass.unscoped.where(ids_hash).arel.compile_update(attributes_with_values)
         end
       end
-      klass.connection.update stmt.to_sql
+      klass.connection.update stmt
     end
   end
 end


### PR DESCRIPTION
##### This is a bug fix for version 5.x 
When connecting to different databases using inheritance, the incorrect syntax is being generated when the databases are of different types.

example:
consider the following class NewBase
```ruby 
class NewBase < ActiveRecord::Base
      self.abstract_class = true
end
```
When first connecting ActiveRecord to mysql and then using NewBase to connect to sqlserver, 
sql updates and saves failed because the query generated was using mysql syntax instead of sqlserver. 

I didn't create a test because I wasn't sure how properly write a test for this bug 

