### PR TITLE
ar_3.2.x Bug Fix: wrong database syntax when using inheritance

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -24,7 +24,7 @@ module ActiveRecord
           where_hash[key.to_s] = self[key]
         end
 
-        # CPK      
+        # CPK
         #relation.bind_values = [[column, id]]
 
         relation = self.class.unscoped.where(where_hash)
@@ -80,7 +80,7 @@ module ActiveRecord
           stmt = klass.unscoped.where(ids_hash).arel.compile_update(attributes_with_values)
         end
       end
-      klass.connection.update stmt.to_sql
+      klass.connection.update stmt
     end
   end
 end


### PR DESCRIPTION
This is a bug fix for ar_3.2.x

First reported here [https://github.com/composite-primary-keys/composite_primary_keys/pull/325]

When connecting to different databases using inheritance, the incorrect syntax is being generated when the databases are of different types.

example:
consider the following class NewBase
```ruby
class NewBase < ActiveRecord::Base
      self.abstract_class = true
end
```
When first connecting ActiveRecord to mysql and then using NewBase to connect to sqlserver,
sql updates and saves failed because the query generated was using mysql syntax instead of sqlserver.

