### PR TITLE
NoMethodError: undefined method `name' for ... Arel::Nodes::SqlLiteral

### DIFF
--- a/lib/composite_primary_keys/arel/visitors/to_sql.rb
+++ b/lib/composite_primary_keys/arel/visitors/to_sql.rb
@@ -7,7 +7,7 @@ module Arel
         else
           # CPK
           # collector = visit o.left, collector
-          if o.left.name.is_a?(Array)
+          if o.left.respond_to?(:name) && o.left.name.is_a?(Array)
             collector << "("
             collector = visit(o.left, collector)
             collector << ")"


### PR DESCRIPTION
When using composite_primary_keys, Arel::Nodes::In#to_sql throws an exceptions when the left side is a Arel::Nodes::SqlLiteral.

Please see this for a reproducible example:
https://gist.github.com/tye/948de93617e5fa1752a7

If you run it, you'll see the exception:

NoMethodError: undefined method `name' for "(SELECT something FROM some_other_table WHERE id = 1)":Arel::Nodes::SqlLiteral

I am experiencing this problem in certain scenarios using Ransack.

In the reproducible example, you can uncomment my branch and comment out the composite-primary-keys branch to see it passes with the patch I am proposing.
