### PR TITLE
"uninitialized constant" when using a has_many through association with a polymorphic source

### DIFF
--- a/lib/composite_primary_keys/associations/has_many_through_association.rb
+++ b/lib/composite_primary_keys/associations/has_many_through_association.rb
@@ -19,7 +19,8 @@ module ActiveRecord
         scope = through_association.scope
         # CPK
         # scope.where! construct_join_attributes(*records)
-        if source_reflection.klass.composite?
+        source_klass = source_reflection.polymorphic? ? klass : source_reflection.klass
+        if source_klass.composite?
           scope.where! cpk_join_through_predicate(*records)
         else
           scope.where! construct_join_attributes(*records)

--- a/test/fixtures/user.rb
+++ b/test/fixtures/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   has_many :articles, :through => :readings
   has_many :comments, :as => :person
   has_many :hacks, :through => :comments, :source => :hack
+  has_many :persons, :through => :comments, :source_type => 'User'
   
   def find_custom_articles
     articles.where("name = ?", "Article One")

--- a/test/test_polymorphic.rb
+++ b/test/test_polymorphic.rb
@@ -24,4 +24,11 @@ class TestPolymorphic < ActiveSupport::TestCase
     user = users(:santiago)
     assert_equal(['andrew'], user.hacks.collect { |a| a.name }.sort)
   end
+  
+  def test_has_many_through_with_polymorphic_source
+    user = users(:santiago)
+    user_to_associate = users(:drnic)
+    user.update_attributes :persons => [user_to_associate]
+    assert_equal user.persons, [user_to_associate]
+  end
 end


### PR DESCRIPTION
When you have a has_many :through association with a polymorphic source:

```ruby
class User < ActiveRecord::Base
  has_many :commenting_users, through: :comments, source: :commenter, source_type: 'User'
end

class Comment < ActiveRecord::Base
  belongs_to :commenter, polymorphic: true
end
```

Trying to set the list of associated objects will fail with a "Uninitialized constant" error:

```ruby
User.find(1).update_attributes commenting_users: [User.find(2), User.find(3)]
```

will result in an exception like:

```ruby
NameError: uninitialized constant Comment::Commenter
```

See the test case I added for a working example of this failure.

In the HasManyThroughAssociation#delete_records method we are looking up the source class on the source_reflection. It doesn't make sense to me to ever do this in the case source_reflection is polymorphic.

Rails forces you to declare a source_type on the association in this case. We should look up the klass on the originating association instead of on the source association.