### PR TITLE
change autosave_association.rb so that association autosave can work

### DIFF
--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -97,6 +97,7 @@ require 'composite_primary_keys/associations/singular_association'
 require 'composite_primary_keys/associations/collection_association'
 
 require 'composite_primary_keys/dirty'
+require 'composite_primary_keys/autosave_association'
 
 require 'composite_primary_keys/attribute_methods/primary_key'
 require 'composite_primary_keys/attribute_methods/dirty'

--- a/lib/composite_primary_keys/arel/visitors/to_sql.rb
+++ b/lib/composite_primary_keys/arel/visitors/to_sql.rb
@@ -8,14 +8,28 @@ module Arel
           # CPK
           # collector = visit o.left, collector
           if o.left.respond_to?(:name) && o.left.name.is_a?(Array)
-            collector << "("
-            collector = visit(o.left, collector)
-            collector << ")"
+=begin
+            new_name = o.left.name.each_with_index.map do |field, idx|
+              table_name = idx == 0 ? "" : "#{@connection.quote_table_name(o.left.relation.name)}."
+              "#{table_name}#{@connection.quote_column_name(field)}"
+            end.join(",")
+
+            o.left.name = Arel::Nodes::SqlLiteral.new("#{new_name}")
+=end
+
+           if @connection.adapter_name == "SQLite"
+            collector << 'EXISTS'
+           else
+              collector << "("
+              collector = visit(o.left, collector)
+              collector << ")"
+            end
           else
             collector = visit o.left, collector
           end
 
-          collector << " IN ("
+          collector << " IN" unless @connection.adapter_name == "SQLite"
+          collector << " ("
           visit(o.right, collector) << ")"
         end
       end

--- a/lib/composite_primary_keys/autosave_association.rb
+++ b/lib/composite_primary_keys/autosave_association.rb
@@ -1,0 +1,31 @@
+module ActiveRecord
+  module AutosaveAssociation
+    private
+      # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.
+      #
+      # In addition, it will destroy the association if it was marked for destruction.
+      def save_belongs_to_association(reflection)
+        association = association_instance_get(reflection.name)
+        record      = association && association.load_target
+        if record && !record.destroyed?
+          autosave = reflection.options[:autosave]
+
+          if autosave && record.marked_for_destruction?
+            self[reflection.foreign_key] = nil
+            record.destroy
+          elsif autosave != false
+            saved = record.save(:validate => !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
+
+            if association.updated?
+              # it will fail to use "#record.send(reflection.options[:primary_key] || :id)" for CPK
+              association_id = record.read_attribute(reflection.options[:primary_key] || :id)
+              self[reflection.foreign_key] = association_id
+              association.loaded!
+            end
+
+            saved if autosave
+          end
+        end
+      end
+  end
+end

--- a/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module DatabaseStatements
+      def join_to_delete(delete, select, key) #:nodoc:
+        subselect = subquery_for(key, select)
+        rewrite_ck(key)
+        delete.where key.in(subselect)
+      end
+
+      private
+        def rewrite_ck(key)
+          if key.respond_to?(:name) && key.name.is_a?(Array)
+            new_name = key.name.each_with_index.map do |field, idx|
+              table_name = idx == 0 ? "" : "#{@connection.quote_table_name(key.relation.name)}."
+              "#{table_name}#{@connection.quote_column_name(field)}"
+            end.join(",")
+
+            key.name = Arel::Nodes::SqlLiteral.new("#{new_name}")
+        end
+
+    end
+  end
+end

--- a/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter
+      # MySQL is too stupid to create a temporary table for use subquery, so we have
+      # to give it some prompting in the form of a subsubquery. Ugh!
+      def subquery_for(key, select)
+        subsubselect = select.clone
+        subsubselect.projections = [key]
+
+        # Materialize subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subsubselect.distinct unless select.limit || select.offset || select.orders.any?
+
+        subselect = Arel::SelectManager.new(select.engine)
+
+        #subselect.project Arel.sql(key.name)
+        arel_table = select.engine.arel_table
+        subselect.project *key.name.map{|x| arel_table[x]}
+        subselect.from subsubselect.as('__active_record_temp')
+      end
+    end
+  end
+end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -81,6 +81,16 @@ class TestAssociations < ActiveSupport::TestCase
     refute_equal accounting_head, engineering_head
   end
 
+  def test_association_with_composite_primary_key_can_be_autosaved
+    room = Room.new(dorm_id: 1000, room_id: 1001)
+    room_assignment = RoomAssignment.new(student_id: 1000)
+    room_assignment.room = room
+    room_assignment.save
+    room_assignment.reload
+    assert_equal(room_assignment.dorm_id, 1000)
+    assert_equal(room_assignment.room_id, 1001)
+  end
+
   def test_has_one_association_primary_key_and_foreign_key_are_present
     steve = employees(:steve)
     steve_salary = steve.create_one_salary(year: "2015", month: "1")


### PR DESCRIPTION
Without patching ```autosave_association.rb```, below case will fail with error
```TypeError: [:dorm_id, :room_id] is not a symbol nor a string```

```
    room = Room.new(dorm_id: 1000, room_id: 1001)
    room_assignment = RoomAssignment.new(student_id: 1000)
    room_assignment.room = room
    room_assignment.save
```

The change is to fix the issue by using ```record.read_attribute``` instead of ```record.send``` in ```autosave_association.rb```.