### PR TITLE
change autosave_association.rb so that association autosave can work

### DIFF
--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -97,6 +97,7 @@ require 'composite_primary_keys/associations/singular_association'
 require 'composite_primary_keys/associations/collection_association'
 
 require 'composite_primary_keys/dirty'
+require 'composite_primary_keys/autosave_association'
 
 require 'composite_primary_keys/attribute_methods/primary_key'
 require 'composite_primary_keys/attribute_methods/dirty'

--- a/lib/composite_primary_keys/autosave_association.rb
+++ b/lib/composite_primary_keys/autosave_association.rb
@@ -1,0 +1,31 @@
+module ActiveRecord
+  module AutosaveAssociation
+    private
+      # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.
+      #
+      # In addition, it will destroy the association if it was marked for destruction.
+      def save_belongs_to_association(reflection)
+        association = association_instance_get(reflection.name)
+        record      = association && association.load_target
+        if record && !record.destroyed?
+          autosave = reflection.options[:autosave]
+
+          if autosave && record.marked_for_destruction?
+            self[reflection.foreign_key] = nil
+            record.destroy
+          elsif autosave != false
+            saved = record.save(:validate => !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
+
+            if association.updated?
+              # it will fail to use "#record.send(reflection.options[:primary_key] || :id)" for CPK
+              association_id = record.read_attribute(reflection.options[:primary_key] || :id)
+              self[reflection.foreign_key] = association_id
+              association.loaded!
+            end
+
+            saved if autosave
+          end
+        end
+      end
+  end
+end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -81,6 +81,16 @@ class TestAssociations < ActiveSupport::TestCase
     refute_equal accounting_head, engineering_head
   end
 
+  def test_association_with_composite_primary_key_can_be_autosaved
+    room = Room.new(dorm_id: 1000, room_id: 1001)
+    room_assignment = RoomAssignment.new(student_id: 1000)
+    room_assignment.room = room
+    room_assignment.save
+    room_assignment.reload
+    assert_equal(room_assignment.dorm_id, 1000)
+    assert_equal(room_assignment.room_id, 1001)
+  end
+
   def test_has_one_association_primary_key_and_foreign_key_are_present
     steve = employees(:steve)
     steve_salary = steve.create_one_salary(year: "2015", month: "1")


### PR DESCRIPTION
Without patching ```autosave_association.rb```, below case will fail with error
```TypeError: [:dorm_id, :room_id] is not a symbol nor a string```

```
    room = Room.new(dorm_id: 1000, room_id: 1001)
    room_assignment = RoomAssignment.new(student_id: 1000)
    room_assignment.room = room
    room_assignment.save
```

The change is to fix the issue by using ```record.read_attribute``` instead of ```record.send``` in ```autosave_association.rb```.