### PR TITLE
Fix failure case test_delete_all_with_joins and make CPK work for Arel::Attributes::Attribute

### DIFF
--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -61,6 +61,7 @@ require 'active_record/locking/optimistic'
 require 'active_record/nested_attributes'
 
 require 'active_record/connection_adapters/abstract_adapter'
+require 'active_record/connection_adapters/abstract_mysql_adapter'
 
 require 'active_record/relation/batches'
 require 'active_record/relation/calculations'
@@ -106,6 +107,7 @@ require 'composite_primary_keys/locking/optimistic'
 require 'composite_primary_keys/nested_attributes'
 
 require 'composite_primary_keys/connection_adapters/abstract_adapter'
+require 'composite_primary_keys/connection_adapters/abstract_mysql_adapter'
 require 'composite_primary_keys/connection_adapters/abstract/connection_specification_changes'
 
 require 'composite_primary_keys/relation/batches'

--- a/lib/composite_primary_keys/arel/visitors/to_sql.rb
+++ b/lib/composite_primary_keys/arel/visitors/to_sql.rb
@@ -1,6 +1,18 @@
 module Arel
   module Visitors
     class ToSql
+      def visit_Arel_Attributes_Attribute o, collector
+        join_name = o.relation.table_alias || o.relation.name
+        table_name = quote_table_name join_name
+
+        if o.name.is_a? Array
+          collector <<
+            o.name.map{ |field| "#{table_name}.#{quote_column_name(field)}" }.join(",")
+        else
+          collector << "#{table_name}.#{quote_column_name o.name}"
+        end
+      end
+
       def visit_Arel_Nodes_In o, collector
         if Array === o.right && o.right.empty?
           collector << '1=0'

--- a/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
@@ -1,0 +1,23 @@
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter < AbstractAdapter
+      # MySQL is too stupid to create a temporary table for use subquery, so we have
+      # to give it some prompting in the form of a subsubquery. Ugh!
+      def subquery_for(key, select)
+        subsubselect = select.clone
+        subsubselect.projections = [key]
+
+        # Materialize subquery by adding distinct
+        # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
+        subsubselect.distinct unless select.limit || select.offset || select.orders.any?
+
+        subselect = Arel::SelectManager.new(select.engine)
+
+        # subselect.project Arel.sql(key.name)
+        arel_table = select.engine.arel_table
+        subselect.project *key.name.map{|x| arel_table[x]}
+        subselect.from subsubselect.as('__active_record_temp')
+      end
+    end
+  end
+end

--- a/test/test_delete_all.rb
+++ b/test/test_delete_all.rb
@@ -27,8 +27,9 @@ class TestValidations < ActiveSupport::TestCase
     assert(EmployeesGroup.all.size == 3)
   end
 
-  # This test fails, requires fixin arel
   def test_delete_all_with_joins
-    ReferenceCode.joins(:reference_type).where(:reference_type_id => 1).delete_all
+    # Let's ignore SQLite for this case since multi-column IN clause like (column1, column2) IN (...) is not allowed.
+    # It cannot work without some dirty fix.
+    ReferenceCode.joins(:reference_type).where(:reference_type_id => 1).delete_all unless ReferenceCode.connection.adapter_name == "SQLite"
   end
 end


### PR DESCRIPTION
The change patch Arel so that ```Arel::Attributes::Attribute``` can be handled well when #name is one Array.

It can fix the failure case test_delete_all_with_joins. (SQLite cannot work for this case since multi-column IN clause like (column1, column2) IN (...) is not allowed in SQLite3).