### PR TITLE
Bugfix/ar_4.0.x: read from attribute rather than `send` in uniqueness validation

### DIFF
--- a/lib/composite_primary_keys/validations/uniqueness.rb
+++ b/lib/composite_primary_keys/validations/uniqueness.rb
@@ -27,7 +27,7 @@ module ActiveRecord
         end
 
         Array.wrap(options[:scope]).each do |scope_item|
-          scope_value = record.send(scope_item)
+          scope_value = record.read_attribute(scope_item)
           relation = relation.and(table[scope_item].eq(scope_value))
         end
 


### PR DESCRIPTION
As corrected in https://github.com/rails/rails/pull/7072