### PR TITLE
Create OR predicates in a nicely balanced tree.

### DIFF
--- a/test/test_predicates.rb
+++ b/test/test_predicates.rb
@@ -22,6 +22,25 @@ class TestEqual < ActiveSupport::TestCase
     assert_equal(with_quoted_identifiers(expected), pred.to_sql)
   end
 
+  def test_or_with_many_values
+    dep = Arel::Table.new(:departments)
+
+    predicates = Array.new
+
+    number_of_predicates = 30000 # This should really be big
+    number_of_predicates.times do |i|
+      predicates << dep[:id].eq(i)
+    end
+
+    connection = ActiveRecord::Base.connection
+    quoted = "#{connection.quote_table_name('departments')}.#{connection.quote_column_name('id')}"
+    expected_ungrouped = ((0...number_of_predicates).map { |i| "#{quoted} = #{i}" }).join(' OR ')
+    expected = "(#{expected_ungrouped})"
+
+    pred = cpk_or_predicate(predicates)
+    assert_equal(with_quoted_identifiers(expected), pred.to_sql)
+  end
+
   # def test_and
   #   dep = Arel::Table.new(:departments)
   #


### PR DESCRIPTION
The creation is done recursively instead of blindly iteratively.
This has the advantage when generating the actual SQL code the
depth of the tree will be a lot smaller (log_2), and as a result
will not generate a stack level too deep problem.

This fixes #320