### PR TITLE
Don't nest PK twice when looking up id, fixes #319

### DIFF
--- a/lib/composite_primary_keys/attribute_methods/read.rb
+++ b/lib/composite_primary_keys/attribute_methods/read.rb
@@ -7,7 +7,8 @@ module ActiveRecord
           _read_attribute(attr_name, &block)
         else
           name = attr_name.to_s
-          name = self.class.primary_key if name == 'id'.freeze
+          # CPK
+          name = self.class.primary_key if name == 'id'.freeze && !composite?
           _read_attribute(name, &block)
         end
       end

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -218,3 +218,12 @@ create table employees_groups (
   employee_id int not null,
   group_id int not null
 );
+
+create table pk_called_ids (
+    id serial not null,
+    reference_code    int         not null,
+    code_label        varchar(50) default null,
+    abbreviation      varchar(50) default null,
+    description       varchar(50) default null,
+    primary key (id, reference_code)
+);

--- a/test/fixtures/pk_called_id.rb
+++ b/test/fixtures/pk_called_id.rb
@@ -1,0 +1,5 @@
+class PkCalledId < ActiveRecord::Base
+  self.primary_keys = :id, :reference_code
+
+  validates_presence_of :reference_code, :code_label, :abbreviation
+end

--- a/test/fixtures/pk_called_ids.yml
+++ b/test/fixtures/pk_called_ids.yml
@@ -1,0 +1,11 @@
+name_prefix_mr:
+  id: 1
+  reference_code: 1
+  code_label: MR
+  abbreviation: Mr
+
+name_prefix_mrs:
+  id: 2
+  reference_code: 1
+  code_label: MRS
+  abbreviation: Mrs

--- a/test/test_ids.rb
+++ b/test/test_ids.rb
@@ -4,7 +4,7 @@ class ChildCpkTest < ReferenceCode
 end
 
 class TestIds < ActiveSupport::TestCase
-  fixtures :reference_types, :reference_codes
+  fixtures :reference_types, :reference_codes, :pk_called_ids
   
   CLASSES = {
     :single => {
@@ -18,6 +18,10 @@ class TestIds < ActiveSupport::TestCase
     :dual_strs   => {
       :class => ReferenceCode,
       :primary_keys => ['reference_type_id', 'reference_code'],
+    },
+    :pk_called_id => {
+      :class => PkCalledId,
+      :primary_keys => ['id', 'reference_code'],
     },
   }
 


### PR DESCRIPTION
For tables that have ID column and use composite primary keys, the id attribute
is already overridden to fetch multiple attributes. This change prevents
nesting the entire primary key in the first element for invocations of id,
matching the behavior in the ar_4.1.x branch.