### PR TITLE
Fix `establish_connection` not working with string

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/connection_specification_changes.rb
@@ -10,6 +10,13 @@ module ActiveRecord
     end
 
     def self.establish_connection(spec = nil)
+      # NOTE: When passing a string `spec` such as `"development"`,
+      # it needs to be casted to symbol `:development`,
+      # due to the `resolver` expecting a Hash or a symbol.
+      if spec.is_a?(String)
+        spec.to_sym!
+      end
+
       spec     ||= ActiveRecord::ConnectionHandling::DEFAULT_ENV.call.to_sym
       resolver =   ConnectionAdapters::ConnectionSpecification::Resolver.new configurations
       spec     =   resolver.spec(spec, self == Base ? "primary" : name)


### PR DESCRIPTION
When passing a string `spec` such as `"development"`,
it needs to be casted to symbol `:development`,
due to the `resolver` expecting a Hash or a symbol.

Example usage:

```
class ReportingApplicationRecord < ActiveRecord::Base
  self.abstract_class = true

  # BROKEN - And now fixed
  establish_connection('reporting_db')
  # GOOD - Still working
  establish_connection(:reporting_db)
end
```

@cfis @codeodor 