### PR TITLE
Fix TestIds#test_set_ids_string

### DIFF
--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -206,7 +206,7 @@ create table employees_groups (
 );
 
 create table pk_called_ids (
-    id serial not null,
+    id integer not null,
     reference_code    int         not null,
     code_label        varchar(50) default null,
     abbreviation      varchar(50) default null,


### PR DESCRIPTION
The one failing test left on sqlite3 was a mistake in copying pk_called_ids DDL.