### PR TITLE
fix incorrect case statement to get PK for SQLServer

### DIFF
--- a/lib/composite_primary_keys/arel/sqlserver.rb
+++ b/lib/composite_primary_keys/arel/sqlserver.rb
@@ -26,9 +26,9 @@ module Arel
               t[name]
             end
           when NilClass
-            [t[column_name]]
-          else
             nil
+          else
+            [t[column_name]]
         end
       end
     end


### PR DESCRIPTION
Seems like the branches of the case statement are inverted, fixes https://github.com/composite-primary-keys/composite_primary_keys/issues/383