### PR TITLE
Address ORA-00900 error when it attempts to execute blank statement

### DIFF
--- a/tasks/databases/oracle.rake
+++ b/tasks/databases/oracle.rake
@@ -14,7 +14,7 @@ namespace :oracle do
     sql = File.read(schema)
 
     sql.split(';').each do |command|
-      ActiveRecord::Base.connection.execute(command)
+      ActiveRecord::Base.connection.execute(command) unless command.blank?
     end
 
     ActiveRecord::Base.clear_all_connections!


### PR DESCRIPTION
This pull request addresses `ActiveRecord::StatementInvalid: OCIError: ORA-00900: invalid SQL statement:` when `rake oracle:build_database` command executed:

This is due to rake task was attempting to run empty string. 

```ruby
$ bundle exec rake oracle:build_database
rake aborted!
ActiveRecord::StatementInvalid: OCIError: ORA-00900: invalid SQL statement:
stmt.c:243:in oci8lib_220.so
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:17:in `block (3 levels) in <top (required)>'
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:16:in `each'
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:16:in `block (2 levels) in <top (required)>'
/home/yahonda/.rbenv/versions/2.2.2/bin/bundle:23:in `load'
/home/yahonda/.rbenv/versions/2.2.2/bin/bundle:23:in `<main>'
OCIError: ORA-00900: invalid SQL statement
stmt.c:243:in oci8lib_220.so
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:17:in `block (3 levels) in <top (required)>'
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:16:in `each'
/home/yahonda/git/composite_primary_keys/tasks/databases/oracle.rake:16:in `block (2 levels) in <top (required)>'
/home/yahonda/.rbenv/versions/2.2.2/bin/bundle:23:in `load'
/home/yahonda/.rbenv/versions/2.2.2/bin/bundle:23:in `<main>'
Tasks: TOP => oracle:build_database
(See full trace by running task with --trace)
$
```

```ruby
$ bundle show
Gems included by the bundle:
  * activemodel (5.0.2)
  * activerecord (5.0.2)
  * activerecord-oracle_enhanced-adapter (1.7.10)
  * activerecord-sqlserver-adapter (5.0.6 6197f0b)
  * activesupport (5.0.2)
  * arel (7.1.4)
  * bundler (1.14.5)
  * concurrent-ruby (1.0.5)
  * i18n (0.8.1)
  * mini_portile2 (2.1.0)
  * minitest (5.10.1)
  * mysql2 (0.4.5)
  * pg (0.19.0)
  * rake (12.0.0)
  * ruby-oci8 (2.2.3)
  * ruby-plsql (0.6.0)
  * sqlite3 (1.3.13)
  * thread_safe (0.3.6)
  * tiny_tds (1.1.0)
  * tzinfo (1.2.2)
```