### PR TITLE
Use `datetime` to address Invalid default value for 'updated_at'

### DIFF
--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -39,8 +39,8 @@ create table tariffs (
     tariff_id int not null,
     start_date date not null,
     amount integer(11) default null,
-    created_at timestamp,
-    updated_at timestamp,
+    created_at datetime,
+    updated_at datetime,
     primary key (tariff_id, start_date)
 );
 


### PR DESCRIPTION
#### Steps to reproduce:
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-linux]
MySQL `Server version: 5.7.17-0ubuntu0.16.10.1 (Ubuntu)`
composite_primary_keys master branch


#### Steps to reproduce:
```ruby
$ rake mysql:build_database
rake aborted!
ActiveRecord::StatementInvalid: Mysql2::Error: Invalid default value for 'updated_at':

create table tariffs (
    tariff_id int not null,
    start_date date not null,
    amount integer(11) default null,
    created_at timestamp,
    updated_at timestamp,
    primary key (tariff_id, start_date)
)
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `_query'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `block in query'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `handle_interrupt'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `query'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:218:in `block in execute'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
/var/lib/gems/2.4.0/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:218:in `execute'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/mysql/database_statements.rb:31:in `execute'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:27:in `block (3 levels) in <top (required)>'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:26:in `each'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:26:in `block (2 levels) in <top (required)>'
/var/lib/gems/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
Mysql2::Error: Invalid default value for 'updated_at'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `_query'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:120:in `block in query'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `handle_interrupt'
/var/lib/gems/2.4.0/gems/mysql2-0.4.5/lib/mysql2/client.rb:119:in `query'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:218:in `block in execute'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
/var/lib/gems/2.4.0/gems/activesupport-5.0.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:218:in `execute'
/var/lib/gems/2.4.0/gems/activerecord-5.0.2/lib/active_record/connection_adapters/mysql/database_statements.rb:31:in `execute'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:27:in `block (3 levels) in <top (required)>'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:26:in `each'
/home/ubuntu/composite_primary_keys/tasks/databases/mysql.rake:26:in `block (2 levels) in <top (required)>'
/var/lib/gems/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => mysql:build_database
(See full trace by running task with --trace)
$
```



Since MySQL 5.7, `sql_mode` contains `NO_ZERO_DATE`, which prevents
from creating 0 value for timestamp columns.

Changing `timestamp` to `datetime` as ActiveRecord timestamps type does.