### PR TITLE
UnknownPrimaryKey error

### DIFF
--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -56,7 +56,7 @@ module ActiveRecord
       # Don't like this method name, but its modeled after how AR does it
       def reset_primary_keys
         if self != base_class
-          self.primary_keys = base_class.primary_keys
+          self.primary_keys = base_class.primary_keys if base_class.primary_keys.present?
         end
       end
 


### PR DESCRIPTION
```ruby
def primary_keys
  unless defined?(@primary_keys)
    reset_primary_keys
  end
  @primary_keys
end

# Don't like this method name, but its modeled after how AR does it
def reset_primary_keys
  if self != base_class
    self.primary_keys = base_class.primary_keys
  end
end

class Foo
end

class Bar < Foo
end
```

when Bar call #primary_keys(`Bar.primary_keys`)
will be call `#reset_primary_keys` 
=> `Bar.primary_keys = nil`
=> `Bar.primary_key == nil` #true
then will raise `UnknownPrimaryKey`