### PR TITLE
Fix sqlserver undefined local variable or method `schema_cache'

### DIFF
--- a/lib/composite_primary_keys/arel/sqlserver.rb
+++ b/lib/composite_primary_keys/arel/sqlserver.rb
@@ -16,7 +16,8 @@ module Arel
 
       def primary_Key_From_Table t
         return unless t
-        column_name = schema_cache.primary_keys(t.name) || column_cache(t.name).first.second.try(:name)
+        column_name = @connection.schema_cache.primary_keys(t.name) ||
+          @connection.schema_cache.columns_hash(t.name).first.try(:second).try(:name)
 
         # CPK
         # column_name ? t[column_name] : nil


### PR DESCRIPTION
I've just updated primary_Key_From_Table method to match current code base of activerecord-sqlserver-adapter to fix **NameError: undefined local variable or method `schema_cache'**  error.

See https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/620baf2be175cfdb5333aa11c69f8efafb65fff6/lib/arel/visitors/sqlserver.rb#L193-L194

I'm not sure whether it should be merged to master or separate branch. 
Please correct me if I am wrong.

rails (5.1.3)
activerecord-sqlserver-adapter (5.1.1)