### PR TITLE
Fix Paper Trail compatibility

### DIFF
--- a/lib/composite_primary_keys/nested_attributes.rb
+++ b/lib/composite_primary_keys/nested_attributes.rb
@@ -59,9 +59,7 @@ module ActiveRecord
           attributes = attributes.with_indifferent_access
           if attributes['id'].blank?
             unless reject_new_record?(association_name, attributes)
-              new_record = association.build(attributes.except(*UNASSIGNABLE_KEYS))
-              public_send("#{self.attributes.keys.first}_will_change!") # TODO CPK: Note: Is this a bug in Rails? We need to somehow set the parent model as changed even when changes are only adding new records to an association. This is not the way to do it, but I am not sure how it should be done.
-              new_record
+              association.build(attributes.except(*UNASSIGNABLE_KEYS))
             end
           elsif existing_record = cpk_detect_record(attributes['id'], existing_records)
             unless call_reject_if(association_name, attributes)
@@ -76,9 +74,7 @@ module ActiveRecord
                 association.add_to_target(existing_record, :skip_callbacks)
               end
 
-              result_from_assign = assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
-              public_send("#{self.attributes.keys.first}_will_change!") # TODO CPK: Note: Is this a bug in Rails? We need to somehow set the parent model as changed even when changes are only adding new records to an association. This is not the way to do it, but I am not sure how it should be done.
-              result_from_assign
+              assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])
             end
           else
             raise_nested_attributes_record_not_found!(association_name, attributes['id'])

--- a/test/test_nested_attributes.rb
+++ b/test/test_nested_attributes.rb
@@ -8,7 +8,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
     code_id = 1001
 
     reference_type = reference_types(:name_prefix)
-    reference_type.update_attribute :reference_codes_attributes, [{
+    reference_type.update_attributes :reference_codes_attributes => [{
       :reference_code => code_id,
       :code_label => 'XX',
       :abbreviation => 'Xx'
@@ -20,7 +20,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
     code_id = 1002
 
     reference_type = reference_types(:name_prefix)
-    reference_type.update_attribute :reference_codes_attributes, [{
+    reference_type.update_attributes :reference_codes_attributes => [{
       :reference_code => code_id,
       :code_label => 'XX',
       :abbreviation => 'Xx'
@@ -28,7 +28,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
 
     reference_code = ReferenceCode.find_by_reference_code(code_id)
     cpk = CompositePrimaryKeys::CompositeKeys[reference_type.reference_type_id, code_id]
-    reference_type.update_attribute :reference_codes_attributes, [{
+    reference_type.update_attributes :reference_codes_attributes => [{
       :id => cpk,
       :code_label => 'AAA',
       :abbreviation => 'Aaa'
@@ -71,7 +71,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
     platform = 'instagram'
 
     topic = topics(:music)
-    topic.update_attribute :topic_sources_attributes, [{
+    topic.update_attributes :topic_sources_attributes => [{
       :platform => platform,
       :keywords => 'funk'
     }]
@@ -82,7 +82,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
     platform = 'instagram'
 
     topic = topics(:music)
-    topic.update_attribute :topic_sources_attributes, [{
+    topic.update_attributes :topic_sources_attributes => [{
       :platform => platform,
       :keywords => 'funk'
     }]
@@ -90,7 +90,7 @@ class TestNestedAttributes < ActiveSupport::TestCase
 
     topic_source = TopicSource.find_by_platform(platform)
     cpk = CompositePrimaryKeys::CompositeKeys[topic.id, platform]
-    topic.update_attribute :topic_sources_attributes, [{
+    topic.update_attributes :topic_sources_attributes => [{
       :id => cpk,
       :keywords => 'jazz'
     }]


### PR DESCRIPTION
This fixes #412 by removing `*_will_change!` calls added in #348 via https://github.com/composite-primary-keys/composite_primary_keys/commit/dc0cc456be228748cc0416d7d19d477744dee97a.

Originally `update_attribute` in [Rails 4.2](https://github.com/rails/rails/blob/v4.2.0/activerecord/lib/active_record/persistence.rb#L239) called save no matter if changes existed. [Rails 5.0](https://github.com/rails/rails/blob/v5.0.0/activerecord/lib/active_record/persistence.rb#L255) updated it to only save if `changed?`, and [Rails 5.1](https://github.com/rails/rails/blob/v5.1.0/activerecord/lib/active_record/persistence.rb#L270) updated it to call a new method, `has_changes_to_save?`. The problem is these methods don't return true if only an association was updated, even if the call to save would actually end up committing changes.

This is a change in Rails behavior that I'm sure isn't considered a bug by Rails core team, so we shouldn't introduce a bug into Paper Trail by attempting to patch it. This commit removes the patch, and updates the failing tests to instead call `update_attributes`, which always calls `save`.