### PR TITLE
Fix a quoting error which occur in rare cases

### DIFF
--- a/lib/composite_primary_keys/associations/association_scope.rb
+++ b/lib/composite_primary_keys/associations/association_scope.rb
@@ -37,15 +37,11 @@ module ActiveRecord
           hash
         end
 
-        if scope.table == table
-          scope = scope.where(joins)
-        else
-          scope = scope.where(table.name => joins)
-        end
+        scope = cpk_apply_scope(scope, table, joins)
 
         if reflection.type
           polymorphic_type = transform_value(owner.class.base_class.name)
-          scope = scope.where(table.name => { reflection.type => polymorphic_type })
+          scope = cpk_apply_scope(scope, table, { reflection.type => polymorphic_type })
         end
 
         scope
@@ -62,10 +58,20 @@ module ActiveRecord
 
         if reflection.type
           value = transform_value(next_reflection.klass.base_class.name)
-          scope = scope.where(table.name => { reflection.type => value })
+          scope = cpk_apply_scope(scope, table, { reflection.type => value })
         end
 
         scope = scope.joins(join(foreign_table, constraint))
+      end
+
+      private
+
+      def cpk_apply_scope(scope, table, joins)
+        if scope.table == table
+          scope.where(joins)
+        else
+          scope.where(table.name => joins)
+        end
       end
     end
   end

--- a/lib/composite_primary_keys/associations/association_scope.rb
+++ b/lib/composite_primary_keys/associations/association_scope.rb
@@ -36,7 +36,12 @@ module ActiveRecord
           hash[mapping.first] = transform_value(owner[mapping.last])
           hash
         end
-        scope = scope.where(table.name => joins)
+
+        if scope.table == table
+          scope = scope.where(joins)
+        else
+          scope = scope.where(table.name => joins)
+        end
 
         if reflection.type
           polymorphic_type = transform_value(owner.class.base_class.name)

--- a/test/fixtures/db_definitions/db2-create-tables.sql
+++ b/test/fixtures/db_definitions/db2-create-tables.sql
@@ -124,3 +124,15 @@ create table products_restaurants (
   franchise_id integer not null,
   store_id integer not null
 );
+
+create table same_named_things (
+    id integer not null,
+    same_named_things varchar(50) not null,
+    primary key (id)
+);
+
+create table ugly_things (
+    id integer not null,
+    same_named_thing_id integer not null,
+    primary key (id)
+);

--- a/test/fixtures/db_definitions/db2-drop-tables.sql
+++ b/test/fixtures/db_definitions/db2-drop-tables.sql
@@ -17,3 +17,5 @@ drop table RESTAURANTS_SUBURBS;
 drop table PRODUCTS_RESTAURANTS;
 drop table TOPICS;
 drop table TOPIC_SOURCES;
+drop table SAME_NAMED_THINGS;
+drop table UGLY_THINGS;

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -225,3 +225,15 @@ create table pk_called_ids (
   description varchar(50) default null,
   primary key (id, reference_code)
 );
+
+create table same_named_things (
+    id integer not null,
+    same_named_things varchar(50) not null,
+    primary key (id)
+);
+
+create table ugly_things (
+    id integer not null,
+    same_named_thing_id integer not null,
+    primary key (id)
+);

--- a/test/fixtures/db_definitions/oracle.drop.sql
+++ b/test/fixtures/db_definitions/oracle.drop.sql
@@ -48,3 +48,5 @@ drop table products_restaurants;
 drop table employees_groups;
 drop table pk_called_ids;
 drop sequence pk_called_ids_seq;
+drop table same_named_things;
+drop table ugly_things;

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -244,3 +244,15 @@ create table pk_called_ids (
     description       varchar(50) default null,
     constraint pk_called_ids_pk primary key (id, reference_code)
 );
+
+create table same_named_things (
+    id number(11) not null,
+    same_named_things varchar(50) not null,
+    primary key (id)
+);
+
+create table ugly_things (
+    id number(11) not null,
+    same_named_thing_id number(11) not null,
+    primary key (id)
+);

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -227,3 +227,15 @@ create table pk_called_ids (
     description       varchar(50) default null,
     primary key (id, reference_code)
 );
+
+create table same_named_things (
+    id serial not null,
+    same_named_things varchar(50) not null,
+    primary key (id)
+);
+
+create table ugly_things (
+    id serial not null,
+    same_named_thing_id int not null,
+    primary key (id)
+);

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -212,3 +212,15 @@ create table pk_called_ids (
     description       varchar(50) default null,
     primary key (id, reference_code)
 );
+
+create table same_named_things (
+    id integer not null,
+    same_named_things varchar(50) not null,
+    primary key (id)
+);
+
+create table ugly_things (
+    id integer not null,
+    same_named_thing_id integer not null,
+    primary key (id)
+);

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -210,3 +210,13 @@ CREATE TABLE pk_called_ids (
     CONSTRAINT [pk_called_ids_pk] PRIMARY KEY
         ( [id], [reference_code] )
 );
+
+CREATE TABLE same_named_things (
+    id [int] PRIMARY KEY NOT NULL,
+    same_named_things [varchar](50) NOT NULL
+);
+
+CREATE TABLE ugly_things (
+    id [int] PRIMARY KEY NOT NULL,
+    same_named_thing_id [int] NOT NULL
+);

--- a/test/fixtures/same_named_thing.rb
+++ b/test/fixtures/same_named_thing.rb
@@ -1,0 +1,3 @@
+class SameNamedThing < ActiveRecord::Base
+  has_many :ugly_things
+end

--- a/test/fixtures/same_named_things.yml
+++ b/test/fixtures/same_named_things.yml
@@ -1,0 +1,11 @@
+same_named_thing_x:
+  id: 1
+  same_named_things: 'x'
+
+same_named_thing_y:
+  id: 2
+  same_named_things: 'y'
+
+same_named_thing_z:
+  id: 3
+  same_named_things: 'z'

--- a/test/fixtures/ugly_thing.rb
+++ b/test/fixtures/ugly_thing.rb
@@ -1,0 +1,3 @@
+class UglyThing < ActiveRecord::Base
+  belongs_to :same_named_thing
+end

--- a/test/fixtures/ugly_things.yml
+++ b/test/fixtures/ugly_things.yml
@@ -1,0 +1,11 @@
+ugly_thing_x:
+  id: 1
+  same_named_thing_id: 1
+
+ugly_thing_y:
+  id: 2
+  same_named_thing_id: 2
+
+ugly_thing_z:
+  id: 3
+  same_named_thing_id: 3

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -3,7 +3,7 @@ require File.expand_path('../abstract_unit', __FILE__)
 class TestAssociations < ActiveSupport::TestCase
   fixtures :articles, :products, :tariffs, :product_tariffs, :suburbs, :streets, :restaurants,
            :dorms, :rooms, :room_attributes, :room_attribute_assignments, :students, :room_assignments, :users, :readings,
-           :departments, :employees, :memberships, :membership_statuses
+           :departments, :employees, :memberships, :membership_statuses, :same_named_things, :ugly_things
 
   def test_products
     assert_not_nil products(:first_product).product_tariffs
@@ -345,5 +345,9 @@ class TestAssociations < ActiveSupport::TestCase
     article = Article.new
     article.reading_ids = Reading.pluck(:id)
     assert_equal article.reading_ids, Reading.pluck(:id)
+  end
+
+  def test_association_works_even_if_the_table_has_same_named_columns
+    assert_equal SameNamedThing.first, UglyThing.first.same_named_thing
   end
 end


### PR DESCRIPTION
[Rails 5.1 upgrade — TypeError: can’t quote Hash](https://medium.com/@vvangemert/rails-5-1-upgrade-typeerror-cant-quote-hash-840a093a2a3f)

> We discovered the problem occurred when using a attribute with the same name as the table.

```
/path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/quoting.rb:196:in `_quote': can't quote Hash (TypeError) 
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/connection_adapters/abstract/quoting.rb:25:in `quote'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/statement_cache.rb:52:in `block in sql_for'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/statement_cache.rb:52:in `each'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/statement_cache.rb:52:in `sql_for'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/statement_cache.rb:105:in `execute'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/associations/singular_association.rb:50:in `find_target'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/associations/association.rb:157:in `load_target'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/associations/association.rb:53:in `reload'
  from /path/to/project/.bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/associations/singular_association.rb:7:in `reader'
```
see also:
* [ActiveRecord::ConnectionAdapters::Quoting#_quote](https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L196)
* [ActiveRecord::Associations::AssociationScope#last_chain_scope](https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/associations/association_scope.rb#L63)
* [ActiveRecord::Associations::AssociationScope#apply_scope](https://github.com/rails/rails/blob/v5.1.4/activerecord/lib/active_record/associations/association_scope.rb#L166)
* [Specify `table.name` only when `scope.table` and `table` are different](https://github.com/rails/rails/pull/29058)