### PR TITLE
Fixed for superclass mismatch for class SQLServer when used with activerecord-sqlserver-adapter gem

### DIFF
--- a/lib/composite_primary_keys/arel/sqlserver.rb
+++ b/lib/composite_primary_keys/arel/sqlserver.rb
@@ -1,6 +1,6 @@
 module Arel
   module Visitors
-    class SQLServer
+    class SQLServer < Arel::Visitors::ToSql
       def make_Fetch_Possible_And_Deterministic o
         return if o.limit.nil? && o.offset.nil?
         t = table_From_Statement o


### PR DESCRIPTION
I got `superclass mismatch for class SQLServer` while using the latest version of the gem with 
`activerecord-sqlserver-adapter` gem. 

This is because both gems declare Arel::Visitors for SQLServer.

**activerecord-sqlserver-adapter**

https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/blob/620baf2be175cfdb5333aa11c69f8efafb65fff6/lib/arel/visitors/sqlserver.rb#L3

```ruby
module Arel
  module Visitors
    class SQLServer < Arel::Visitors::ToSql
```
**composite_primary_keys**

https://github.com/composite-primary-keys/composite_primary_keys/blob/c7d22013d0ded02e35a37d054e3a92d19df99b93/lib/composite_primary_keys/arel/sqlserver.rb#L3

The composite_primary_keys gem doesn't inherit from `Arel::Visitors::ToSql`, which is the convention in ActiveRecord.