### PR TITLE
Set inversion when using preload Rails 5.1.x

### DIFF
--- a/lib/composite_primary_keys/associations/preloader/association.rb
+++ b/lib/composite_primary_keys/associations/preloader/association.rb
@@ -43,6 +43,8 @@ module ActiveRecord
               records.each do |record, owner_key|
                 owners_map[owner_key].each do |owner|
                   records_by_owner[owner] << record
+                  association = owner.association(reflection.name)
+                  association.set_inverse_instance(record)
                 end
               end
             end

--- a/test/test_preload.rb
+++ b/test/test_preload.rb
@@ -91,4 +91,11 @@ class TestPreload < ActiveSupport::TestCase
     assert_equal(1, employees.first.groups_2.size)
     assert_equal(2, employees.second.groups_2.size)
   end
+
+  def test_preload_settings_inversion
+    users = User.preload(:readings).all
+    reading = users.first.readings.first
+
+    assert_equal(true, reading.association(:user).loaded?)
+  end
 end


### PR DESCRIPTION
Thanks for making this awesome gem.
We had N+1 problem when upgrading to Rails 5.1.5 using composite-primary-keys v10.0.3

Assuming we have `Country` and `City` model and `Country` has_many `City`.
```ruby
countries = Country.preload(:cities)
city = countries.first.cities.first
city.association(:country).loaded? #=> false
city.country # will trigger call to DB
```

Not sure why inversion is not set. The difference lies in these 2 lines: https://github.com/rails/rails/blob/v5.1.5/activerecord/lib/active_record/associations/preloader/association.rb#L63-L64

I noticed that tests failed due to the recent update in `mysql2` from `0.4.10` to `0.5.0` and made a separate PR to address the issue: #434 
