### PR TITLE
Lock mysql2 to ~> v0.4.0 for Rails 5.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 # end
 
 group :mysql do
-  gem 'mysql2'
+  gem 'mysql2', '~> 0.4.0'
 end
 
 group :oracle do


### PR DESCRIPTION
I noticed it will fail if checking out from `ar_5.1.x` because `mysql2` just updated `0.5.0` recently

Example failed build: https://travis-ci.org/composite-primary-keys/composite_primary_keys/jobs/359215301