### PR TITLE
Add friendly error for incomplete args

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', ['~>5.1.0', '>= 5.1.5']
+gem 'activerecord', ['~>5.1.0', '<= 5.1.5']
 gem 'rake'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency('activerecord', ['~> 5.1.0', '>= 5.1.5'])
+  s.add_dependency('activerecord', ['~> 5.1.0', '<= 5.1.5'])
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mysql2')

--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -114,3 +114,5 @@ require 'composite_primary_keys/composite_relation'
 require 'composite_primary_keys/arel/in'
 require 'composite_primary_keys/arel/to_sql'
 require 'composite_primary_keys/arel/sqlserver'
+
+require 'composite_primary_keys/errors'

--- a/lib/composite_primary_keys/errors.rb
+++ b/lib/composite_primary_keys/errors.rb
@@ -1,0 +1,27 @@
+module CompositePrimaryKeys
+  # = Composite Primary Keys Errors
+  #
+  # Generic Composite Primary Keys exception class.
+  class CompositePrimaryKeysError < StandardError
+  end
+
+  # Raised when finder method receives incomplete arguments
+  #
+  #   class Department < ActiveRecord::Base
+  #     self.primary_keys = :department_id, :location_id
+  #   end
+  #
+  #   # A single integer can not be mapped to composite primary keys
+  #   # this call raises a IncompleteArgumentsError
+  #   Department.find(1)
+  class IncompleteArgumentsError < CompositePrimaryKeysError
+    def initialize(klass, primary_key, args)
+      super <<-MSG.lstrip
+      Can not map arguments to composite primary key
+  args: #{args}
+  primary_key: #{primary_key.inspect}
+  class: #{klass}
+      MSG
+    end
+  end
+end

--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -86,6 +86,14 @@ module CompositePrimaryKeys
         expects_array = ids.flatten != ids.flatten(1)
         return ids.first if expects_array && ids.first.empty?
 
+        if primary_key.is_a?(Array)
+          ids.each do |search_id|
+            next if search_id.is_a?(Array) && search_id.compact.length == primary_key.length
+            raise CompositePrimaryKeys::IncompleteArgumentsError
+                    .new(@klass, primary_key, search_id)
+          end
+        end
+
         # CPK
         # ids = ids.flatten.compact.uniq
         ids = expects_array ? ids.first : ids

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -120,6 +120,44 @@ class TestFind < ActiveSupport::TestCase
     assert_equal([1,3], ref_code.id)
   end
 
+  def test_find_with_incomplete_id
+    begin
+      ReferenceCode.find(1)
+    rescue StandardError => e
+      assert_kind_of(CompositePrimaryKeys::IncompleteArgumentsError, e)
+      assert_match('primary_key: ["reference_type_id", "reference_code"]', e.message)
+      assert_match('args: 1', e.message)
+      assert_match('class: ReferenceCode', e.message)
+    end
+  end
+
+  def test_find_some_with_incomplete_id
+    begin
+      ReferenceCode.find([1,1], 2)
+    rescue StandardError => e
+      assert_kind_of(CompositePrimaryKeys::IncompleteArgumentsError, e)
+      assert_match('args: 2', e.message)
+    end
+  end
+
+  def test_find_with_malformed_string
+    begin
+      ReferenceCode.find('1,1', '1,')
+    rescue StandardError => e
+      assert_kind_of(CompositePrimaryKeys::IncompleteArgumentsError, e)
+      assert_match('args: ["1"]', e.message)
+    end
+  end
+
+  def test_find_with_nil_value
+    begin
+      ReferenceCode.find([1,nil])
+    rescue StandardError => e
+      assert_kind_of(CompositePrimaryKeys::IncompleteArgumentsError, e)
+      assert_match('args: [1, nil]', e.message)
+    end
+  end
+
   def test_find_some_with_array_of_params_id
     params_ids = ReferenceCode.find([1,3], [2,1]).map(&:to_param)
     assert_equal ["1,3", "2,1"], params_ids


### PR DESCRIPTION
One of the things I've found frustrating about working with `composite_primary_keys` is that the errors it generates tend to be cryptic and not helpful for figuring out what actually went wrong. This PR seeks to begin addressing that.

I've added `CompositePrimaryKeys::IncompleteArgumentsError`, which is raised when `.find()` is called with fewer arguments than are expected.

```ruby
# Given a class with composite primary keys
class Department < ActiveRecord::Base
  self.primary_keys = :department_id, :location_id
end

Department.find(1)
# ...
# CompositePrimaryKeys::IncompleteArgumentsError (Can not map arguments to composite primary key)
#   args: 1
#   primary key: ["department_id", "location_id"]
#   class: Department
```

Also covered:
```ruby
# These all raise CompositePrimaryKeys::IncompleteArgumentsError
Department.find([1,nil])
Department.find([1,1], 2)
Department.find('1,1', '2')
Department.find('1,')
```

