### PR TITLE
Convert batches to arrays before continuing loop

### DIFF
--- a/lib/composite_primary_keys/relation/batches.rb
+++ b/lib/composite_primary_keys/relation/batches.rb
@@ -59,7 +59,7 @@ module CompositePrimaryKeys
             end.reduce(:or)
           end
 
-          records = relation.where(query)
+          records = relation.where(query).to_a
         end
       end
 


### PR DESCRIPTION
This is the same concept as used in the main rails code here:

https://github.com/rails/rails/blob/v4.2.10/activerecord/lib/active_record/relation/batches.rb#L128

Before looping to the next iteration of `find_in_batches` we populate the relation to an array.  Without this the `while records.any?` check at the top of the loop ends up performing an extra count query, and at worse it was crashing for me (but that might have been an interaction with another gem I'm using)