### PR TITLE
API change in AR 5.2.x

### DIFF
--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -18,7 +18,7 @@ module CompositePrimaryKeys
         end
 
         if block_given?
-          relation._select!(join_dependency.aliases.columns)
+          join_dependency.apply_column_aliases(relation)
           yield relation, join_dependency
         else
           relation


### PR DESCRIPTION
[ActiveRecord::Associations::JoinDependency#aliases](https://github.com/rails/rails/commit/50036e673b3b6ff41476814b212b55fabac3a638#diff-06059df8d3dee3101718fb2c01151ad0R134) was made private.

A new method [#apply_column_aliases](https://github.com/rails/rails/commit/50036e673b3b6ff41476814b212b55fabac3a638#diff-06059df8d3dee3101718fb2c01151ad0R126) was added.

At first glance this new method appears to orchestrate a similar interaction as in the call replaced
below.

I submit this commit having checked the postgresql tests. I'll see what else I have available to test... Or hopefully the CI will take it!

Attempts to fix: https://github.com/composite-primary-keys/composite_primary_keys/issues/459