### PR TITLE
Fix key not being an array in subquery on has_many :through

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
         # subselect.project Arel.sql(key.name)
         arel_table = select.engine.arel_table
-        subselect.project *key.name.map{|x| arel_table[x]}
+        subselect.project *[key].map { |x| arel_table[x.name] }
         subselect.from subsubselect.as('__active_record_temp')
       end
     end

--- a/test/test_update_all.rb
+++ b/test/test_update_all.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestUpdateAll < ActiveSupport::TestCase
+  fixtures :articles, :users
+
+  def test_update_all
+    first_article = Article.first
+    users_count = first_article.users.count
+    # limit forces a subquery
+    first_article.users.limit(1).update_all(name: 'test')
+    assert_equal(
+      User.joins(readings: :article)
+        .merge(Article.where(id: first_article))
+        .where(name: 'test').count, users_count
+    )
+  end
+end


### PR DESCRIPTION
Hi,

We've encountered an error while updating to 8.1.6 (our app is Rails 4).
```
NoMethodError: undefined method `map' for "id":String
Did you mean?  tap
        from /Users/eproulx/.rbenv/versions/2.3.7/lib/ruby/gems/2.3.0/gems/composite_primary_keys-8.1.6/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb:18:in `subquery_for'
        from /Users/eproulx/.rbenv/versions/2.3.7/lib/ruby/gems/2.3.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:334:in `join_to_update'
        from /Users/eproulx/.rbenv/versions/2.3.7/lib/ruby/gems/2.3.0/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:354:in `join_to_update'
        from /Users/eproulx/.rbenv/versions/2.3.7/lib/ruby/gems/2.3.0/gems/activerecord-4.2.10/lib/active_record/relation.rb:337:in `update_all'
```

I fixed it with a test :)

