### PR TITLE
Stay close to the original implementation of Association#run

### DIFF
--- a/lib/composite_primary_keys/associations/preloader/association.rb
+++ b/lib/composite_primary_keys/associations/preloader/association.rb
@@ -43,7 +43,7 @@ module ActiveRecord
                       convert_key(key)
                     end
                   else
-                    record[association_key_name]
+                    convert_key(record[association_key_name])
                   end
 
             owner = owners_by_key[key]

--- a/test/test_preload.rb
+++ b/test/test_preload.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../abstract_unit', __FILE__)
 
 class TestPreload < ActiveSupport::TestCase
-  fixtures :comments, :users, :employees, :groups, :hacks
+  fixtures :comments, :users, :employees, :groups, :hacks, :readings
 
   class UserForPreload < User
     has_many :comments_with_include_condition, -> { where('person_type = ?', 'User')},


### PR DESCRIPTION
The original implementation passes the key to the `convert_method` before fetching the owner. This commit restores the conversion behaviour.

Haven't figured out a case where this actually applies. Just hit this while trying to make preloading case insensitive by overriding this method :woman_shrugging: 

Not entirely sure what's wrong with the sqlite tests :thinking: 