### PR TITLE
CI: Use 2.6.3, drop 2.4.6 (Rails 6 requires 2.5.0+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ bundler_args: --without "oracle sqlserver"
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake mysql:build_database postgresql:build_database sqlite:build_database
+  - bundle exec rake mysql:build_database postgresql:build_database sqlite:build_database
 
 script:
-  - "rake postgresql:test"
-  - "rake sqlite:test"
-  - "rake mysql:test"
+  - "bundle exec rake postgresql:test"
+  - "bundle exec rake sqlite:test"
+  - "bundle exec rake mysql:test"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,8 @@ rvm:
 env:
   - CPK_LOGFILE=log/test.log
 
+addons:
+  postgresql: "9.4"
+
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ script:
   - "rake mysql:test"
 
 rvm:
-  - 2.4.6
   - 2.5.5
   - 2.6.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ rvm:
 
 env:
   - CPK_LOGFILE=log/test.log
+
+services:
+  - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,21 @@ script:
   - "rake sqlite:test"
   - "rake mysql:test"
 
-rvm:
-  - 2.5.5
-  - 2.6.3
-
 env:
-  - CPK_LOGFILE=log/test.log
+  global:
+    - CPK_LOGFILE=log/test.log
+
+matrix:
+  include:
+    - name: "Ruby 2.6 with Rails 6"
+      rvm: 2.6.3
+      env: RAILS_VERSION="~> 6.0.0.beta3"
+    - name: "Ruby 2.5 with Rails 6"
+      rvm: 2.5.5
+      env: RAILS_VERSION="~> 6.0.0.beta3"
+    - name: "Ruby 2.4 with Rails 5"
+      rvm: 2.4.6
+      env: RAILS_VERSION="~> 5.2"
 
 addons:
   postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 bundler_args: --without "oracle sqlserver"
 
 before_script:
@@ -12,9 +11,9 @@ script:
   - "rake mysql:test"
 
 rvm:
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
-  - 2.6.2
+  - 2.6.3
 
 env:
   - CPK_LOGFILE=log/test.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,13 @@ script:
   - "bundle exec rake sqlite:test"
   - "bundle exec rake mysql:test"
 
+rvm:
+  - 2.6.3
+  - 2.5.5
+
 env:
   global:
     - CPK_LOGFILE=log/test.log
-
-matrix:
-  include:
-    - name: "Ruby 2.6 with Rails 6"
-      rvm: 2.6.3
-      env: RAILS_VERSION="~> 6.0.0.beta3"
-    - name: "Ruby 2.5 with Rails 6"
-      rvm: 2.5.5
-      env: RAILS_VERSION="~> 6.0.0.beta3"
-    - name: "Ruby 2.4 with Rails 5"
-      rvm: 2.4.6
-      env: RAILS_VERSION="~> 5.2"
 
 addons:
   postgresql: "9.4"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 6.0.0.beta3'
+gem 'activerecord', ENV.fetch('RAILS_VERSION', '~> 6.0.0.beta3')
 gem 'rake'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', ENV.fetch('RAILS_VERSION', '~> 6.0.0.beta3')
+gem 'activerecord', '~> 6.0.0.beta3'
 gem 'rake'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 


### PR DESCRIPTION
This PR updates the CI configuration on the `master` branch:

- use Ruby 2.6.3 in the matrix
- use PostgreSQL 9.4 - Fixes #484 
- remove Ruby 2.4.6 from the matrix - Rails 6 requires at least Ruby 2.5.0, and we're fixed on that version
- remove the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

This makes the build 💚 green.