### PR TITLE
Reset id if part of it was generated during insertion

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -64,7 +64,7 @@ module ActiveRecord
       new_id = self.class._insert_record(attributes_values)
 
       # CPK
-      if self.composite? && self.id.compact.empty?
+      if self.composite? && self.id.compact.size != self.class.primary_keys.size
         self.id = new_id
       else
         self.id ||= new_id if self.class.primary_key


### PR DESCRIPTION
I found out that the gem doesn't reset id if part of it was already set before calling `create` this was causing trouble for me as I have a partitioned table by `tenant_id` but still use sequence to fill in a default for `id`.

This change resets `id` in that case. 

What do you think? Am I right doing it here?