### PR TITLE
Fix for #497 (ORA-00920: invalid relational operator with CPK 12.0.0)

### DIFF
--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -91,9 +91,6 @@ module ActiveRecord
         stmt.key = arel_attribute(primary_key)
         stmt.wheres = arel.constraints
       end
-      stmt.take(arel.limit)
-      stmt.offset(arel.offset)
-      stmt.order(*arel.orders)
 
       affected = @klass.connection.delete(stmt, "#{@klass} Destroy")
 
@@ -112,7 +109,7 @@ module ActiveRecord
 
       key_name = Array(key).map {|a_key| a_key.name }.join(',')
 
-      Arel::SelectManager.new(subselect.as("__active_record_temp")).project(Arel.sql(key_name))
+      Arel::SelectManager.new(subselect.as("active_record_temp")).project(Arel.sql(key_name))
     end
   end
 end

--- a/test/fixtures/restaurant.rb
+++ b/test/fixtures/restaurant.rb
@@ -1,6 +1,6 @@
 class Restaurant < ActiveRecord::Base
   self.primary_keys = :franchise_id, :store_id
-  has_and_belongs_to_many :suburbs, 
+  has_and_belongs_to_many :suburbs, -> { order("name ") },
     :foreign_key => [:franchise_id, :store_id],  
     :association_foreign_key => [:city_id, :suburb_id]
   has_and_belongs_to_many :products,

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -2,7 +2,7 @@ require File.expand_path('../abstract_unit', __FILE__)
 
 class TestDelete < ActiveSupport::TestCase
   fixtures :articles, :departments, :employees, :products, :tariffs, :product_tariffs,
-           :reference_types, :reference_codes
+           :reference_types, :reference_codes, :suburbs, :restaurants, :restaurants_suburbs
 
   def test_delete_one
     assert_equal(5, ReferenceCode.count)
@@ -165,6 +165,15 @@ class TestDelete < ActiveSupport::TestCase
 
     product.reload
     assert_equal(1, product.product_tariffs.length)
+  end
+
+  def test_delete_all_with_sort
+    mcdonalds = restaurants(:mcdonalds)
+    assert_equal(2, mcdonalds.suburbs.length)
+
+    mcdonalds.suburbs.where(name: 'First Suburb').delete_all
+    mcdonalds.reload
+    assert_equal(1, mcdonalds.suburbs.length)
   end
 
   def test_delete_records_for_has_many_association_with_composite_primary_key


### PR DESCRIPTION
The name of the subquery alias on Oracle cannot start with the underscore character.
See: https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/Database-Object-Names-and-Qualifiers.html#GUID-75337742-67FD-4EC0-985F-741C93D918DA

This change also fixes an issue when deleting all records if the association
contains an order option.