### PR TITLE
Convert attribute names to strings before checking for them in has_attribute?

### DIFF
--- a/lib/composite_primary_keys/attribute_methods.rb
+++ b/lib/composite_primary_keys/attribute_methods.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     def has_attribute?(attr_name)
       # CPK
       # attributes.key?(attr_name)
-      Array(attr_name).all? {|single_attr| attributes.key?(single_attr) }
+      Array(attr_name).all? {|single_attr| attributes.key?(single_attr.to_s) }
     end
   end
 end


### PR DESCRIPTION
Hi there, we're running into a bug with [Simple Form](https://github.com/plataformatec/simple_form) in which column names specified as symbols aren't being recognized as valid attributes on our models. I believe I've traced the problem down to the override of `has_attribute?` in this gem. 

[Rails's version of `has_attribute?`](https://github.com/rails/rails/blob/1811e841166198bf86ae6de18d0971df77b932b4/activerecord/lib/active_record/attribute_methods.rb#L237) first converts the specified attribute name to a string with `to_s`, which is what was missing from this override. 

Working from my fork with this patch has fixed the issue for us. 

I wasn't able to run the tests (`rake postgresql:build_database` kept failing for me), but it looks like you folks have integrated CI so I'm hoping they'll run automatically with this PR. 

And thanks for your work on this library! 