### PR TITLE
Pk with default values

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -64,7 +64,7 @@ module ActiveRecord
       new_id = self.class._insert_record(attributes_values)
 
       # CPK
-      if self.composite? && self.id.compact.empty?
+      if self.composite? && self.id.any?(&:nil?)
         self.id = new_id
       else
         self.id ||= new_id if self.class.primary_key

--- a/test/fixtures/cpk_with_default_value.rb
+++ b/test/fixtures/cpk_with_default_value.rb
@@ -1,0 +1,3 @@
+class CpkWithDefaultValue < ActiveRecord::Base
+  self.primary_keys = :record_id, :record_version
+end

--- a/test/fixtures/cpk_with_default_values.yml
+++ b/test/fixtures/cpk_with_default_values.yml
@@ -1,0 +1,7 @@
+first:
+  record_id: 1
+  record_version: First
+  
+second:
+  record_id: 1
+  record_version: Second

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -216,3 +216,9 @@ create table pk_called_ids (
   description varchar(50) default null,
   primary key (id, reference_code)
 );
+
+create table cpk_with_default_values (
+  record_id integer not null,
+  record_version varchar(50) default '' not null,
+  primary key (record_id, record_version)
+);

--- a/test/fixtures/db_definitions/oracle.drop.sql
+++ b/test/fixtures/db_definitions/oracle.drop.sql
@@ -46,3 +46,5 @@ drop table products_restaurants;
 drop table employees_groups;
 drop table pk_called_ids;
 drop sequence pk_called_ids_seq;
+drop table cpk_with_default_values;
+drop sequence cpk_with_default_values_seq;

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -234,3 +234,11 @@ create table pk_called_ids (
     description       varchar(50) default null,
     constraint pk_called_ids_pk primary key (id, reference_code)
 );
+
+create sequence cpk_with_default_values_seq start with 1000;
+
+create table cpk_with_default_values (
+    record_id         int not null,
+    record_version    varchar(50) default '' not null,
+    constraint cpk_with_default_values_pk primary key (record_id, record_version)
+);

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -218,3 +218,9 @@ create table pk_called_ids (
     description       varchar(50) default null,
     primary key (id, reference_code)
 );
+
+create table cpk_with_default_values (
+    record_id serial not null,
+    record_version varchar(50) default '' not null,
+    primary key (record_id, record_version)
+);

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -204,3 +204,9 @@ create table pk_called_ids (
     description       varchar(50) default null,
     primary key (id, reference_code)
 );
+
+create table cpk_with_default_values (
+    record_id integer not null,
+    record_version    varchar(50) default '' not null,
+    primary key (record_id, record_version)
+);

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -211,3 +211,10 @@ CREATE TABLE pk_called_ids (
     CONSTRAINT [pk_called_ids_pk] PRIMARY KEY
         ( [id], [reference_code] )
 );
+
+CREATE TABLE cpk_with_default_values (
+    record_id         [int] IDENTITY(1000,1) NOT NULL,
+    record_version    [varchar](50) default '' NOT NULL
+    CONSTRAINT [cpk_with_default_values_pk] PRIMARY KEY
+        ( [record_id], [record_version] )
+);

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../abstract_unit', __FILE__)
 
 class TestCreate < ActiveSupport::TestCase
-  fixtures :articles, :students, :dorms, :rooms, :room_assignments, :reference_types, :reference_codes, :streets, :suburbs
+  fixtures :articles, :students, :dorms, :rooms, :room_assignments, :reference_types, :reference_codes, :streets, :suburbs, :cpk_with_default_values
 
   CLASSES = {
     :single => {
@@ -179,5 +179,19 @@ class TestCreate < ActiveSupport::TestCase
 
     suburb = Suburb.find_or_create_by!(:name => 'New Suburb', :city_id => 3, :suburb_id => 1)
     refute_nil(suburb)
+  end
+
+  def test_create_when_pk_has_default_value
+    first = CpkWithDefaultValue.create!
+    refute_nil(first.record_id)
+    assert_equal('', first.record_version)
+
+    second = CpkWithDefaultValue.create!(record_id: first.record_id, record_version: 'Same id, different version')
+    assert_equal(first.record_id, second.record_id)
+    assert_equal('Same id, different version', second.record_version)
+
+    third = CpkWithDefaultValue.create!(record_version: 'Created by version only')
+    refute_nil(third.record_id)
+    assert_equal('Created by version only', third.record_version)
   end
 end


### PR DESCRIPTION
If one of the composite keys have a default value, creating a new record results in the primary key attributes, not being assigned the database generated values from the incremental keys.

This is caused by ActiveRecords behaviour of pre-assigning default values on initialize which conflicts with this library's check of only assigning the primary keys if all of those attributes are nil. 

My tests showcase a scenario where one of the composite keys have an empty string as default value, but the other one is a normal incremental integer (could also be a uuid). This could be useful if you want one of the composite keys to act as the (primary) primary-key, but want to have the option of adding an alternative version for some of the records.

Since no column used as a primary key, can be NULL, it should be sufficient to check if any of the primary key attributes are nil, when determining if it should be assigned or not.

I have prepared tests for all the supported databases, but personally only tested this against the Postgres database.