### PR TITLE
Only run the CPK code in update_all and delete_all when necessary

### DIFF
--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -30,6 +30,8 @@ module ActiveRecord
 
       # CPK
       if @klass.composite? && stmt.to_sql =~ /['"]#{primary_key.to_s}['"]/
+        stmt.table(table)
+
         arel_attributes = primary_keys.map do |key|
           arel_attribute(key)
         end.to_composite_keys


### PR DESCRIPTION
This resolves a performance issue on MySQL when running through the CPK version of the code.

Average test run on particular production data in my app showed a decrease from <unknown number because it was running for longer than 28 minutes so I stopped it> down to 928.0ms.

