### PR TITLE
Fix issue #505 pk with comma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
 
 env:
-  - CPK_LOGFILE=log/test.log
+  global:
+    - CPK_LOGFILE=log/test.log
+
+services:
+  - postgresql
+  - mysql

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('activerecord', '~> 4.2.0')
 
-  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('sqlite3', '~> 1.3.6')
   s.add_development_dependency('pg', '~> 0.15')
   s.add_development_dependency('mysql2', '0.4.4')
   s.add_development_dependency 'rake', '>= 0.9.0'

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '~> 4.2.0')
 
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('pg')
+  s.add_development_dependency('pg', '~> 0.15')
   s.add_development_dependency('mysql2', '0.4.4')
   s.add_development_dependency 'rake', '>= 0.9.0'
 

--- a/lib/composite_primary_keys/associations/preloader/association.rb
+++ b/lib/composite_primary_keys/associations/preloader/association.rb
@@ -64,7 +64,7 @@ module ActiveRecord
           @preloaded_records.map { |record|
             key = Array(association_key_name).map do |key_name|
               record[key_name]
-            end.join(CompositePrimaryKeys::ID_SEP)
+            end.to_composite_keys.to_s
 
             [record, key]
           }
@@ -77,7 +77,7 @@ module ActiveRecord
                                  # owner[owner_key_name].to_s
                                  Array(owner_key_name).map do |key_name|
                                    owner[key_name]
-                                 end.join(CompositePrimaryKeys::ID_SEP)
+                                 end.to_composite_keys.to_s
                                end
                              else
                                owners.group_by do |owner|
@@ -85,10 +85,9 @@ module ActiveRecord
                                  # owner[owner_key_name]
                                  Array(owner_key_name).map do |key_name|
                                    owner[key_name]
-                                 end.join(CompositePrimaryKeys::ID_SEP)
+                                 end.to_composite_keys.to_s
                                end
                              end
-                             
         end
       end
     end

--- a/lib/composite_primary_keys/base.rb
+++ b/lib/composite_primary_keys/base.rb
@@ -186,7 +186,7 @@ module ActiveRecord
       end
 
       def to_param
-        persisted? ? to_key.join(CompositePrimaryKeys::ID_SEP) : nil
+        persisted? ? to_key.to_composite_keys.to_s : nil
       end
     end
   end

--- a/lib/composite_primary_keys/composite_arrays.rb
+++ b/lib/composite_primary_keys/composite_arrays.rb
@@ -1,6 +1,7 @@
 module CompositePrimaryKeys
   ID_SEP     = ','
   ID_SET_SEP = ';'
+  ESCAPE_CHAR = '^'
 
   module ArrayExtension
     def to_composite_keys
@@ -8,12 +9,27 @@ module CompositePrimaryKeys
     end
   end
 
-  def self.normalize(ids)
+  # Convert mixed representation of CPKs (by strings or arrays) to normalized
+  # representation (just by arrays).
+  #
+  # `ids` is Array that may contain:
+  # 1. A CPK represented by an array or a string.
+  # 2. An array of CPKs represented by arrays or strings.
+  #
+  # There is an issue. Let `ids` contain an array with serveral strings. We can't distinguish case 1
+  # from case 2 there in general. E.g. the item can be an array containing appropriate number of strings,
+  # and each string can contain appropriate number of commas. We consider case 2 to win there.
+  def self.normalize(ids, cpk_size)
     ids.map do |id|
-      if id.is_a?(Array)
-        normalize(id)
-      elsif id.is_a?(String) && id.index(ID_SEP)
-        id.split(ID_SEP)
+      if Utils.cpk_as_array?(id, cpk_size) && id.any? { |item| !Utils.cpk_as_string?(item, cpk_size) }
+        # CPK as an array - case 1
+        id
+      elsif id.is_a?(Array)
+        # An array of CPKs - case 2
+        normalize(id, cpk_size)
+      elsif id.is_a?(String)
+        # CPK as a string - case 1
+        CompositeKeys.parse(id)
       else
         id
       end
@@ -27,7 +43,7 @@ module CompositePrimaryKeys
       when Array
         value.to_composite_keys
       when String
-        self.new(value.split(ID_SEP))
+        value.split(ID_SEP).map { |key| Utils.unescape_string_key(key) }.to_composite_keys
       else
         raise(ArgumentError, "Unsupported type: #{value}")
       end
@@ -35,9 +51,36 @@ module CompositePrimaryKeys
 
     def to_s
       # Doing this makes it easier to parse Base#[](attr_name)
-      join(ID_SEP)
+      map { |key| Utils.escape_string_key(key.to_s) }.join(ID_SEP)
     end
   end
+
+  module Utils
+    class << self
+      def escape_string_key(key)
+        key.gsub(Regexp.union(ESCAPE_CHAR, ID_SEP)) do |unsafe|
+          "#{ESCAPE_CHAR}#{unsafe.ord.to_s(16).upcase}"
+        end
+      end
+
+      def unescape_string_key(key)
+        key.gsub(/#{Regexp.escape(ESCAPE_CHAR)}[0-9a-fA-F]{2}/) do |escaped|
+          char = escaped.slice(1, 2).hex.chr
+          (char == ESCAPE_CHAR || char == ID_SEP) ? char : escaped
+        end
+      end
+
+      def cpk_as_array?(value, pk_size)
+        # We don't permit Array to be an element of CPK.
+        value.is_a?(Array) && value.size == pk_size && value.none? { |item| item.is_a?(Array) }
+      end
+
+      def cpk_as_string?(value, pk_size)
+        value.is_a?(String) && value.count(ID_SEP) == pk_size - 1
+      end
+    end
+  end
+  private_constant :Utils
 end
 
 Array.send(:include, CompositePrimaryKeys::ArrayExtension)

--- a/lib/composite_primary_keys/connection_adapters/abstract_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_adapter.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       def quote_column_names(name)
         Array(name).map do |col|
           quote_column_name(col.to_s)
-        end.join(CompositePrimaryKeys::ID_SEP)
+        end.to_composite_keys.to_s
       end
     end
   end

--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -84,7 +84,7 @@ module CompositePrimaryKeys
 
         # CPK
         # expects_array = ids.first.kind_of?(Array)
-        ids = CompositePrimaryKeys.normalize(ids)
+        ids = CompositePrimaryKeys.normalize(ids, @klass.primary_keys.length)
         expects_array = ids.flatten != ids.flatten(1)
 
         return ids.first if expects_array && ids.first.empty?
@@ -138,7 +138,7 @@ module CompositePrimaryKeys
 
         result = ids.map do |cpk_ids|
           cpk_ids = if cpk_ids.length == 1
-            cpk_ids.first.split(CompositePrimaryKeys::ID_SEP).to_composite_keys
+            CompositePrimaryKeys::CompositeKeys.parse(cpk_ids.first)
           else
             cpk_ids.to_composite_keys
           end

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -202,8 +202,8 @@ create table seats (
 );
 
 create table capitols (
-  country varchar(100) default null,
-  city varchar(100) default null,
+  country varchar(100) not null,
+  city varchar(100) not null,
   primary key (country, city)
 );
 

--- a/test/test_composite_arrays.rb
+++ b/test/test_composite_arrays.rb
@@ -21,4 +21,18 @@ class CompositeArraysTest < ActiveSupport::TestCase
     assert_equal CompositePrimaryKeys::CompositeKeys, keys.class
     assert_equal '1,2,3', keys.to_s
   end
+
+  def test_parse
+    assert_equal ['1', '2'], CompositePrimaryKeys::CompositeKeys.parse('1,2')
+    assert_equal ['The USA', '^Washington, D.C.'],
+                 CompositePrimaryKeys::CompositeKeys.parse('The USA,^5EWashington^2C D.C.')
+    assert_equal ['The USA', '^Washington, D.C.'],
+                 CompositePrimaryKeys::CompositeKeys.parse(['The USA', '^Washington, D.C.'])
+  end
+
+  def test_to_s
+    assert_equal '1,2', CompositePrimaryKeys::CompositeKeys.new([1, 2]).to_s
+    assert_equal 'The USA,^5EWashington^2C D.C.',
+                 CompositePrimaryKeys::CompositeKeys.new(['The USA', '^Washington, D.C.']).to_s
+  end
 end

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -41,6 +41,14 @@ class TestFind < ActiveSupport::TestCase
     assert_equal(['The Netherlands', 'Amsterdam'], capitol.id)
   end
 
+  def test_find_with_strings_with_comma_as_composite_keys
+    capitol = Capitol.create!(country: 'The USA', city: 'Washington, D.C.')
+    assert_equal ['The USA', 'Washington, D.C.'], capitol.id
+
+    assert_equal capitol, Capitol.find(['The USA', 'Washington, D.C.'])
+    assert_equal capitol, Capitol.find(capitol.to_param)
+  end
+
   def test_find_each
     room_assignments = []
     RoomAssignment.find_each(:batch_size => 2) do |assignment|

--- a/test/test_ids.rb
+++ b/test/test_ids.rb
@@ -40,6 +40,9 @@ class TestIds < ActiveSupport::TestCase
     testing_with do
       assert_equal '1,1', @first.to_param if composite?
     end
+
+    capitol = Capitol.create!(country: 'The USA', city: 'Washington, D.C.')
+    assert_equal 'The USA,Washington^2C D.C.', capitol.to_param
   end
 
   def test_ids_to_s


### PR DESCRIPTION
The commit fixes an issue when a CPK field contains commas.
Issue: https://github.com/composite-primary-keys/composite_primary_keys/issues/505

CPK is represented by Array or String. Fields in CPK as String are separated by comma. If a CPK field contains a comma, string representation of such CPK is parsed incorrectly. To address the issue,
commas in fields of CPK represented by String are escaped.