### PR TITLE
Remove extra argument from sql_for_insert

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/sqlserver/database_statements.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module DatabaseStatements
-        def sql_for_insert(sql, pk, id_value, sequence_name, binds)
+        def sql_for_insert(sql, pk, binds)
           sql = if pk && self.class.use_output_inserted
             # CPK
             # quoted_pk = SQLServer::Utils.extract_identifiers(pk).quoted


### PR DESCRIPTION
I fixed method arguments for Rails 6 as well as other adapters.

FYI: https://github.com/composite-primary-keys/composite_primary_keys/commit/9a51742b3b3c6c967d3ad2408d80c699dff69be5#diff-52b23807f8898e851aad8bf740baca75