### PR TITLE
Fix .travis.yml to make the tests run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ rvm:
 
 env:
   - CPK_LOGFILE=log/test.log
+
+services:
+  - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ env:
   - CPK_LOGFILE=log/test.log
 
 services:
+  - postgresql
   - mysql


### PR DESCRIPTION
**Descriptoin:**
* Add `mysql` service to `.travis.yml`
  Fixes error in tests:
  ```
  Mysql2::Error::ConnectionError: Can't connect to local MySQL server
  through socket '/var/run/mysqld/mysqld.sock' (2)
  ```
  See https://travis-ci.org/github/composite-primary-keys/composite_primary_keys/builds/654196500

*  Add `postgresql` service to `.travis.yml`
    Fixes error in tests:
    ```
    PG::ConnectionBad: could not connect to server: Connection refused
      Is the server running on host "localhost" (127.0.0.1) and accepting
        TCP/IP connections on port 5432?
    ```
    See https://travis-ci.org/github/composite-primary-keys/composite_primary_keys/builds/661489337

The tests started to run. Some tests fail, they will be fixed in next PRs:
* https://github.com/composite-primary-keys/composite_primary_keys/pull/512