### PR TITLE
Fix overriding AbstractReflection for activerecord 5.2.4

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency('activerecord', '~> 5.2.1')
+  s.add_dependency('activerecord', '~> 5.2.4')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mysql2')

--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -1,19 +1,28 @@
 module ActiveRecord
   module Reflection
     class AbstractReflection
-      def build_join_constraint(table, foreign_table)
+      # Overriding for activerecord v5.2.4
+      def join_scope(table, foreign_table, foreign_klass)
+        predicate_builder = predicate_builder(table)
+        scope_chain_items = join_scopes(table, predicate_builder)
+        klass_scope       = klass_join_scope(table, predicate_builder)
+
         key         = join_keys.key
         foreign_key = join_keys.foreign_key
 
         # CPK
-        #constraint = table[key].eq(foreign_table[foreign_key])
-        constraint = cpk_join_predicate(table, key, foreign_table, foreign_key)
+        # klass_scope.where!(table[key].eq(foreign_table[foreign_key]))
+        klass_scope.where!(cpk_join_predicate(table, key, foreign_table, foreign_key))
+
+        if type
+          klass_scope.where!(type => foreign_klass.polymorphic_name)
+        end
 
         if klass.finder_needs_type_condition?
-          table.create_and([constraint, klass.send(:type_condition, table)])
-        else
-          constraint
+          klass_scope.where!(klass.send(:type_condition, table))
         end
+
+        scope_chain_items.inject(klass_scope, &:merge!)
       end
     end
   end


### PR DESCRIPTION
In https://github.com/rails/rails/commit/54de9b1e4f5823bf22001be60efcb996ce6d260b (v5.2.4)
`ActiveRecord::Reflection::AbstractReflection#build_join_constraint`
method was removed.

Fixes incorrect SQL condition for joining by CPK.