### PR TITLE
Active record 5.2.4 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_script:
 
 script:
   - "rake postgresql:test"
+  - "rake sqlite:test"
+  - "rake mysql:test"
 
 rvm:
   - 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ bundler_args: --without "oracle sqlserver"
 services:
   - mysql
   - postgresql
+  - sqlite
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,18 @@ language: ruby
 sudo: false
 bundler_args: --without "oracle sqlserver"
 
+services:
+  - mysql
+  - postgresql
+
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake postgresql:build_database sqlite:build_database
+  - rake mysql:build_database postgresql:build_database sqlite:build_database
 
 script:
   - "rake postgresql:test"
   - "rake sqlite:test"
-  #- "rake mysql:test"
+  - "rake mysql:test"
 
 rvm:
   - 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,14 @@ bundler_args: --without "oracle sqlserver"
 services:
   - mysql
   - postgresql
-  - sqlite
+  - sqlite3
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake mysql:build_database postgresql:build_database sqlite:build_database
+  - rake mysql:build_database postgresql:build_database
 
 script:
   - "rake postgresql:test"
-  - "rake sqlite:test"
   - "rake mysql:test"
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 script:
   - "rake postgresql:test"
   - "rake sqlite:test"
-  - "rake mysql:test"
+  #- "rake mysql:test"
 
 rvm:
   - 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
 script:
   - "rake postgresql:test"
   - "rake sqlite:test"
-  - "rake mysql:test"
 
 rvm:
   - 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_script:
 
 script:
   - "rake postgresql:test"
-  - "rake sqlite:test"
 
 rvm:
   - 2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ bundler_args: --without "oracle sqlserver"
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake mysql:build_database postgresql:build_database sqlite:build_database
+  - rake postgresql:build_database sqlite:build_database
 
 script:
   - "rake postgresql:test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ services:
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake mysql:build_database postgresql:build_database
+  - rake mysql:build_database postgresql:build_database sqlite:build_database
 
 script:
   - "rake postgresql:test"
   - "rake mysql:test"
+  - "rake sqlite:test"
 
 rvm:
   - 2.4.5

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency('activerecord', '~> 5.2.1')
+  s.add_dependency('activerecord', '~> 5.2.4.2')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mysql2')

--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -1,19 +1,28 @@
 module ActiveRecord
   module Reflection
     class AbstractReflection
-      def build_join_constraint(table, foreign_table)
+      # Overriding for activerecord v5.2.4
+      def join_scope(table, foreign_table, foreign_klass)
+        predicate_builder = predicate_builder(table)
+        scope_chain_items = join_scopes(table, predicate_builder)
+        klass_scope       = klass_join_scope(table, predicate_builder)
+
         key         = join_keys.key
         foreign_key = join_keys.foreign_key
 
         # CPK
-        #constraint = table[key].eq(foreign_table[foreign_key])
-        constraint = cpk_join_predicate(table, key, foreign_table, foreign_key)
+        # klass_scope.where!(table[key].eq(foreign_table[foreign_key]))
+        klass_scope.where!(cpk_join_predicate(table, key, foreign_table, foreign_key))
+
+        if type
+          klass_scope.where!(type => foreign_klass.polymorphic_name)
+        end
 
         if klass.finder_needs_type_condition?
-          table.create_and([constraint, klass.send(:type_condition, table)])
-        else
-          constraint
+          klass_scope.where!(klass.send(:type_condition, table))
         end
+
+        scope_chain_items.inject(klass_scope, &:merge!)
       end
     end
   end

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -1,7 +1,7 @@
 create table topics (
     id int not null auto_increment,
-    name varchar(50) default null,  
-    feed_size int default null, 
+    name varchar(50) default null,
+    feed_size int default null,
     primary key (id)
 );
 
@@ -52,7 +52,7 @@ create table product_tariffs (
 );
 
 create table suburbs (
-    city_id int not null,
+    city_id int not null auto_increment,
     suburb_id int not null,
     name varchar(50) not null,
     primary key (city_id, suburb_id)
@@ -218,7 +218,7 @@ create table pk_called_ids (
 );
 
 create table cpk_with_default_values (
-  record_id integer not null,
+  record_id integer not null auto_increment,
   record_version varchar(50) default '' not null,
   primary key (record_id, record_version)
 );

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -206,7 +206,7 @@ create table pk_called_ids (
 );
 
 create table cpk_with_default_values (
-    record_id integer not null default (rowid),
+    record_id integer not null,
     record_version    varchar(50) default '' not null,
     primary key (record_id, record_version)
 );

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -1,7 +1,7 @@
 create table topics (
-    id int not null,  
-    name varchar(50) default null,  
-    feed_size int default null, 
+    id int not null,
+    name varchar(50) default null,
+    feed_size int default null,
     primary key (id)
 );
 
@@ -169,7 +169,7 @@ create table students (
 create table room_assignments (
 	student_id integer not null,
 	dorm_id integer not null,
-	room_id integer not null	
+	room_id integer not null
 );
 
 create table seats (
@@ -206,7 +206,7 @@ create table pk_called_ids (
 );
 
 create table cpk_with_default_values (
-    record_id integer not null,
+    record_id integer not null default (rowid),
     record_version    varchar(50) default '' not null,
     primary key (record_id, record_version)
 );

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -52,6 +52,7 @@ class TestCreate < ActiveSupport::TestCase
     # Not all databases support columns with multiple identity fields
     postgres = defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && Suburb.connection.class == ActiveRecord::ConnectionAdapters::PostgreSQL
     if postgres
+      raise Suburb.connection.class.inspect
       suburb = Suburb.create!(:name => 'Capitol Hill')
       refute_nil(suburb.city_id)
       refute_nil(suburb.suburb_id)

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -52,7 +52,6 @@ class TestCreate < ActiveSupport::TestCase
     # Not all databases support columns with multiple identity fields
     postgres = defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) && Suburb.connection.class == ActiveRecord::ConnectionAdapters::PostgreSQL
     if postgres
-      raise Suburb.connection.class.inspect
       suburb = Suburb.create!(:name => 'Capitol Hill')
       refute_nil(suburb.city_id)
       refute_nil(suburb.suburb_id)


### PR DESCRIPTION
This is based on https://github.com/composite-primary-keys/composite_primary_keys/pull/512.  Working to get the tests for MySQL and SQL Lite passing.

From #512:
In rails/rails@54de9b1 (v5.2.4)
ActiveRecord::Reflection::AbstractReflection#build_join_constraint
method was removed.

Fixes incorrect SQL condition for joining by CPK.