### PR TITLE
Closes #518 Fix issue with ORM default false values

### DIFF
--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       # CPK
       if self.composite?
         # Merge together the specified id with the new id (specified id gets precedence)
-        self.id = self.id.zip(Array(new_id)).map {|id1, id2| (id1 || id2)}
+        self.id = self.id.zip(Array(new_id)).map {|id1, id2| (id1.nil? ? id2 : id1)}
       else
         self.id ||= new_id if self.class.primary_key
       end

--- a/test/fixtures/cpk_with_default_value.rb
+++ b/test/fixtures/cpk_with_default_value.rb
@@ -1,3 +1,3 @@
 class CpkWithDefaultValue < ActiveRecord::Base
-  self.primary_keys = :record_id, :record_version
+  self.primary_keys = :record_id, :record_version, :published
 end

--- a/test/fixtures/db_definitions/mysql.sql
+++ b/test/fixtures/db_definitions/mysql.sql
@@ -218,7 +218,8 @@ create table pk_called_ids (
 );
 
 create table cpk_with_default_values (
-  record_id integer not null,
+  record_id integer not null auto_increment,
   record_version varchar(50) default '' not null,
-  primary key (record_id, record_version)
+  published boolean default false not null,
+  primary key (record_id, record_version, published)
 );

--- a/test/fixtures/db_definitions/oracle.sql
+++ b/test/fixtures/db_definitions/oracle.sql
@@ -240,5 +240,6 @@ create sequence cpk_with_default_values_seq start with 1000;
 create table cpk_with_default_values (
     record_id         int not null,
     record_version    varchar(50) default '' not null,
-    constraint cpk_with_default_values_pk primary key (record_id, record_version)
+    published         number(1) default 0 not null,
+    constraint cpk_with_default_values_pk primary key (record_id, record_version, published)
 );

--- a/test/fixtures/db_definitions/postgresql.sql
+++ b/test/fixtures/db_definitions/postgresql.sql
@@ -222,5 +222,6 @@ create table pk_called_ids (
 create table cpk_with_default_values (
     record_id serial not null,
     record_version varchar(50) default '' not null,
-    primary key (record_id, record_version)
+    published boolean default false not null,
+    primary key (record_id, record_version, published)
 );

--- a/test/fixtures/db_definitions/sqlite.sql
+++ b/test/fixtures/db_definitions/sqlite.sql
@@ -206,7 +206,8 @@ create table pk_called_ids (
 );
 
 create table cpk_with_default_values (
-    record_id integer not null,
+    record_id integer default 1 not null,
     record_version    varchar(50) default '' not null,
-    primary key (record_id, record_version)
+    published boolean default 0 not null,
+    primary key (record_id, record_version, published)
 );

--- a/test/fixtures/db_definitions/sqlserver.sql
+++ b/test/fixtures/db_definitions/sqlserver.sql
@@ -214,7 +214,8 @@ CREATE TABLE pk_called_ids (
 
 CREATE TABLE cpk_with_default_values (
     record_id         [int] IDENTITY(1000,1) NOT NULL,
-    record_version    [varchar](50) default '' NOT NULL
+    record_version    [varchar](50) default '' NOT NULL,
+    published         [bit] default 0 NOT NULL
     CONSTRAINT [cpk_with_default_values_pk] PRIMARY KEY
-        ( [record_id], [record_version] )
+        ( [record_id], [record_version], [published] )
 );

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -185,6 +185,7 @@ class TestCreate < ActiveSupport::TestCase
     first = CpkWithDefaultValue.create!
     refute_nil(first.record_id)
     assert_equal('', first.record_version)
+    assert_equal(false, first.published)
 
     second = CpkWithDefaultValue.create!(record_id: first.record_id, record_version: 'Same id, different version')
     assert_equal(first.record_id, second.record_id)


### PR DESCRIPTION
This fixes the issue when a field in the composite primary key has a default value of `false`.  See #518   

@cfis I kind of googled and updated the different flavors of DBs, but only really tested on mysql.  Perhaps you have some notes i can update this PR with?