### PR TITLE
Remove deprecation warning for Ruby 2.7

### DIFF
--- a/lib/composite_primary_keys/validations/uniqueness.rb
+++ b/lib/composite_primary_keys/validations/uniqueness.rb
@@ -24,7 +24,7 @@ module ActiveRecord
           error_options = options.except(:case_sensitive, :scope, :conditions)
           error_options[:value] = value
 
-          record.errors.add(attribute, :taken, error_options)
+          record.errors.add(attribute, :taken, **error_options)
         end
       end
     end


### PR DESCRIPTION
Ruby 2.7 has deprecated passing the last argument as a keyword parameter. https://bugs.ruby-lang.org/issues/14183
This warning has already been fixed in Rails https://github.com/rails/rails/blob/master/activerecord/lib/active_record/validations/uniqueness.rb#L38

Fixes this deprecation warning
```
/composite_primary_keys/lib/composite_primary_keys/validations/uniqueness.rb:27: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/rails/activemodel/lib/active_model/errors.rb:395: warning: The called method `add' is defined here
```

The fix is backwards compatible with Ruby < 2.7