### PR TITLE
Add test for #491

### DIFF
--- a/test/fixtures/hack.rb
+++ b/test/fixtures/hack.rb
@@ -1,5 +1,6 @@
 class Hack < ActiveRecord::Base
   has_many :comments, :as => :person
-  
+  has_many :users, :through => :comments, :source => :person, :source_type => "User"
+
   has_one :first_comment, :as => :person, :class_name => "Comment"
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -174,6 +174,12 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal(3, tarrifs_length)
   end
 
+  def test_has_many_through_assign_ids
+    hack = Hack.new(name: "foo", users: User.all)
+    hack.user_ids = [""]
+    assert_empty(hack.user_ids)
+  end
+
   def test_new_style_includes_with_conditions
     product_tariff = ProductTariff.includes(:tariff).where('tariffs.amount < 5').references(:tariffs).first
     assert_equal(0, product_tariff.tariff.amount)


### PR DESCRIPTION
This is a first step to fix #491.

Replacing `if source_reflection.klass.composite?` with `if !source_reflection.polymorphic? && source_reflection.klass.composite?` as suggested by @moiristo makes the tests pass but I'm feeling like this could causes different problems.

@cfis you've got an idea here? :see_no_evil: 

