### PR TITLE
Fix subquery_for for non-cpk

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
         # CPK
         #key_name = quote_column_name(key.name)
-        key_name = [key].flatten.map {|a_key| quote_column_name(a_key.name)}.join(',')
+        key_name = Array.wrap(key).map {|a_key| quote_column_name(a_key.name)}.join(',')
 
         Arel::SelectManager.new(subselect.as("__active_record_temp")).project(Arel.sql(key_name))
       end

--- a/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract_mysql_adapter.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
         # CPK
         #key_name = quote_column_name(key.name)
-        key_name = Array(key).map {|a_key| quote_column_name(a_key.name)}.join(',')
+        key_name = [key].flatten.map {|a_key| quote_column_name(a_key.name)}.join(',')
 
         Arel::SelectManager.new(subselect.as("__active_record_temp")).project(Arel.sql(key_name))
       end

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -41,6 +41,19 @@ class TestDelete < ActiveSupport::TestCase
     assert_equal(3, Department.count)
   end
 
+  def test_delete_all_with_join_non_cpk
+    employee = employees(:steve)
+
+    assert_equal(5, Employee.count)
+
+    Employee.joins(:department).
+               where('departments.department_id = ?', employee.department_id).
+               where('departments.location_id = ?', employee.location_id).
+               delete_all
+
+    assert_equal(3, Employee.count)
+  end
+
   def test_clear_association
     department = Department.find([1,1])
     assert_equal(2, department.employees.size, "Before clear employee count should be 2.")


### PR DESCRIPTION
Within the subquery_for method, 'key' is an array of structs (Arel::Attributes::Attribute) for cpk models and a single struct for non-cpk models. It seems that the code is calling Array(key) assuming that in the case of a single struct you will have an array with one element, which is the struct. Instead, calling [struct.to_a](https://apidock.com/ruby/Struct/to_a) actually takes the struct and turns it into an array, where each field of the array is a field from the struct. Example:
![Screenshot from 2020-06-12 13-38-49](https://user-images.githubusercontent.com/4871884/84544534-53e69d00-acb2-11ea-8a2d-2b9a24740bd7.png)

To achieve the intended result, we can instead call [key].flatten. Example:
![Screenshot from 2020-06-12 13-39-11](https://user-images.githubusercontent.com/4871884/84544550-5cd76e80-acb2-11ea-8827-acbe34aafb74.png)

For reference, here are the same two examples, but with a cpk:
![Screenshot from 2020-06-12 13-33-34](https://user-images.githubusercontent.com/4871884/84544580-6d87e480-acb2-11ea-8469-3baad126684f.png)
![Screenshot from 2020-06-12 13-34-06](https://user-images.githubusercontent.com/4871884/84544593-71b40200-acb2-11ea-83fa-6110e214e405.png)

