### PR TITLE
remove deprecated bundler flag --without

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -113,7 +113,8 @@ divided into the following bundler groups:
 Since it is likely you do not have all the above databases installed on your computer, you want to install just the
 gems for your database.  For example, to test postgresql you would install the appropriate gems like this:
 
-  bundler install --without "mysql oracle sqlite sqlserver"
+  bundler config set --local without "mysql oracle sqlite sqlserver"
+  bundler install
 
 Once you have installed the appropriate gems, the next step is to create the test database. There is a rake
 command for each database. Using our example:


### PR DESCRIPTION
Bundler has [deprecated CLI flags including --without](https://github.com/rubygems/bundler/blob/d4993be66fa2e76b3ca00ea56a51ecab5478b726/UPGRADING.md#cli-deprecations), which is currently in the setup instructions [in the README](https://github.com/composite-primary-keys/composite_primary_keys/blob/master/README.rdoc#tests-).

It also appears you may need to alter your [Travis configs](https://github.com/composite-primary-keys/composite_primary_keys/blob/ac17a99dcfc3a16db9b7b4c9c71234f473b369b3/.travis.yml#L3), though I am not familiar enough with Travis to make the changes. 