### PR TITLE
fix abstract adapter (mysql) create with auto-increment

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb
@@ -6,7 +6,7 @@ module ActiveRecord
         value = exec_insert(sql, name, binds, pk, sequence_name)
 
         # CPK
-        if value && pk.is_a?(Array)
+        if !value&.rows&.empty? && pk.is_a?(Array)
           id_value || value.rows.first
         else
           id_value || last_inserted_id(value)

--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -65,7 +65,7 @@ module ActiveRecord
       )
 
       # CPK
-      if self.composite? && self.id.compact.empty?
+      if self.composite? && self.id&.compact&.empty?
         self.id = self.id.zip(Array(new_id)).map {|id1, id2| (id1 || id2)}
       else
         self.id ||= new_id if self.class.primary_key


### PR DESCRIPTION
fixes #518

With rails 6.0.3.3, cpk 12.0.2, and MariaDB 10.4.14, `exec_insert` with does
not populate value.rows, so we need to use last_inserted_id to get the
id.

Also, self.id is nil, so we need to guard against that case in
Persistence.