### PR TITLE
Fix references to RecordNotFound

### DIFF
--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -92,7 +92,7 @@ module CompositePrimaryKeys
         case ids.size
           when 0
             error_message = "Couldn't find #{model_name} without an ID"
-            raise RecordNotFound.new(error_message, model_name, primary_key)
+            raise ::ActiveRecord::RecordNotFound.new(error_message, model_name, primary_key)
           when 1
             result = find_one(ids.first)
             expects_array ? [ result ] : result
@@ -101,7 +101,7 @@ module CompositePrimaryKeys
         end
       rescue ::RangeError
         error_message = "Couldn't find #{model_name} with an out of range ID"
-        raise RecordNotFound.new(error_message, model_name, primary_key, ids)
+        raise ::ActiveRecord::RecordNotFound.new(error_message, model_name, primary_key, ids)
       end
 
       def last(limit = nil)

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -74,6 +74,18 @@ class TestFind < ActiveSupport::TestCase
     assert_equal(with_quoted_identifiers(expected), error.message)
   end
 
+  def test_find_with_id_out_of_range
+    assert_raise(::ActiveRecord::RecordNotFound) do
+      Suburb.find([1, 1 << 128])
+    end
+  end
+
+  def test_find_without_args
+    assert_raise(::ActiveRecord::RecordNotFound) do
+      Suburb.find
+    end
+  end
+
   def test_find_last_suburb
     suburb = Suburb.last
     assert_equal([2,1], suburb.id)


### PR DESCRIPTION
The change fixes error on referencing `RecordNotFound` inside `CompositePrimaryKeys::ActiveRecord::FinderMethods`:
 ```
 NameError: uninitialized constant CompositePrimaryKeys::ActiveRecord::FinderMethods::RecordNotFound   
 ```
