### PR TITLE
Upgrade to work on Rails 6.1.3

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,6 @@
+== 13.0.0 (unreleased)
+* Update to ActiveRecord 6.0 (Javier Julio, Charlie Savage, Sammy Larbi)
+
 == 12.0.8 (2021-02-16)
 * Revert to previous MySQL/MariaDB auto increment fix
 
@@ -508,7 +511,7 @@ by replacing quoted identifiers with all-caps equivalents on Oracle (Rhett Sutph
 * Update Oracle tests (Rhett Sutphin)
 
 == 4.1.1 2011-08-31
-* Support for AR 3.1.1 
+* Support for AR 3.1.1
 * Make polymorphic belongs_to work in rails 3.1.1 (Tom Hughes)
 * Eliminate relative paths from the test suite (Rhett Sutphin)
 * Minor improvements to the CPK test runner w/o relative path changes (Rhett Sutphin)

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,6 +20,7 @@ Every major version of ActiveRecord has included numerous internal changes.  As 
 CPK has to be rewritten for each version of ActiveRecord.  To help keep
 things straight, here is the mapping:
 
+    Version 13.x is designed to work with ActiveRecord 6.1.x
     Version 12.x is designed to work with ActiveRecord 6.0.x
     Version 11.x is designed to work with ActiveRecord 5.2.x
     Version 10.x is designed to work with ActiveRecord 5.1.x

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 2.5.0'
-  s.add_dependency('activerecord', '~> 6.0.0')
+  s.add_dependency('activerecord', '~> 6.1.0')
   s.add_development_dependency('rake')
 end

--- a/lib/composite_primary_keys.rb
+++ b/lib/composite_primary_keys.rb
@@ -23,7 +23,7 @@
 
 unless defined?(ActiveRecord)
   require 'rubygems'
-  gem 'activerecord', '~>6.0.0'
+  gem 'activerecord', '~>6.1.0'
   require 'active_record'
 end
 
@@ -64,6 +64,7 @@ require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/postgresql/database_statements'
 
 require 'active_record/relation/where_clause'
+require 'active_record/table_metadata'
 
 # CPK overrides
 require_relative 'composite_primary_keys/active_model/attribute_assignment'
@@ -115,3 +116,4 @@ require_relative 'composite_primary_keys/composite_relation'
 
 require_relative 'composite_primary_keys/arel/to_sql'
 require_relative 'composite_primary_keys/arel/sqlserver'
+require_relative 'composite_primary_keys/table_metadata'

--- a/lib/composite_primary_keys/associations/association_scope.rb
+++ b/lib/composite_primary_keys/associations/association_scope.rb
@@ -23,9 +23,8 @@ module ActiveRecord
       end
 
       def last_chain_scope(scope, reflection, owner)
-        join_keys = reflection.join_keys
-        key = join_keys.key
-        foreign_key = join_keys.foreign_key
+        key = reflection.join_primary_key
+        foreign_key = reflection.join_foreign_key
 
         table = reflection.aliased_table
 
@@ -46,9 +45,8 @@ module ActiveRecord
       end
 
       def next_chain_scope(scope, reflection, next_reflection)
-        join_keys = reflection.join_keys
-        key = join_keys.key
-        foreign_key = join_keys.foreign_key
+        key = reflection.join_primary_key
+        foreign_key = reflection.join_foreign_key
 
         table = reflection.aliased_table
         foreign_table = next_reflection.aliased_table

--- a/lib/composite_primary_keys/attribute_methods/primary_key.rb
+++ b/lib/composite_primary_keys/attribute_methods/primary_key.rb
@@ -16,7 +16,6 @@ module ActiveRecord
 
       # Returns the primary key previous value.
       def id_was
-        sync_with_transaction_state
         # CPK
         # attribute_was(self.class.primary_key)
         if self.composite?
@@ -29,7 +28,6 @@ module ActiveRecord
       end
 
       def id_in_database
-        sync_with_transaction_state
         # CPK
         # attribute_in_database(self.class.primary_key)
         if self.composite?

--- a/lib/composite_primary_keys/attribute_methods/read.rb
+++ b/lib/composite_primary_keys/attribute_methods/read.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         # CPK
         # name = primary_key if name == "id" && primary_key
         name = primary_key if name == "id" && primary_key && !composite?
-        sync_with_transaction_state if name == primary_key
+
         _read_attribute(name, &block)
       end
 

--- a/lib/composite_primary_keys/attribute_methods/write.rb
+++ b/lib/composite_primary_keys/attribute_methods/write.rb
@@ -13,7 +13,7 @@ module ActiveRecord
         # CPK
         # name = primary_key if name == "id" && primary_key
         name = primary_key if name == "id" && primary_key && !composite?
-        sync_with_transaction_state if name == primary_key
+
         _write_attribute(name, value)
       end
 

--- a/lib/composite_primary_keys/nested_attributes.rb
+++ b/lib/composite_primary_keys/nested_attributes.rb
@@ -70,7 +70,7 @@ module ActiveRecord
             if target_record
               existing_record = target_record
             else
-              association.add_to_target(existing_record, :skip_callbacks)
+              association.add_to_target(existing_record, skip_callbacks: true)
             end
 
             assign_to_or_mark_for_destruction(existing_record, attributes, options[:allow_destroy])

--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -6,8 +6,8 @@ module ActiveRecord
         scope_chain_items = join_scopes(table, predicate_builder)
         klass_scope       = klass_join_scope(table, predicate_builder)
 
-        key         = join_keys.key
-        foreign_key = join_keys.foreign_key
+        key         = join_primary_key
+        foreign_key = join_foreign_key
 
         # CPK
         #klass_scope.where!(table[key].eq(foreign_table[foreign_key]))
@@ -23,6 +23,63 @@ module ActiveRecord
         end
 
         scope_chain_items.inject(klass_scope, &:merge!)
+      end
+    end
+
+    class AssociationReflection < MacroReflection
+      def foreign_key
+        # CPK
+        # @foreign_key ||= -(options[:foreign_key]&.to_s || derive_foreign_key)
+        @foreign_key ||= begin
+          fk = options[:foreign_key] || derive_foreign_key
+          fk.freeze
+        end
+        raise "cpk called #{@foreign_key}" if @foreign_key == "[:student_id, :district_id]"
+        @foreign_key
+      end
+
+      def association_foreign_key
+        # CPK
+        # @association_foreign_key ||= -(options[:association_foreign_key]&.to_s || class_name.foreign_key)
+        @association_foreign_key ||= begin
+          fk = options[:association_foreign_key] || class_name.foreign_key
+          fk.freeze
+        end
+      end
+
+      def active_record_primary_key
+        # CPK (Rails freezes the string returned in the expression that calculates PK here. But Rails uses the `-` method which is not available on Array for CPK, so we calculate it in one line and freeze it on the next)
+        # @active_record_primary_key ||= -(options[:primary_key]&.to_s || primary_key(active_record))
+        @active_record_primary_key ||= begin
+          pk = options[:primary_key] || primary_key(active_record)
+          pk.freeze
+        end
+      end
+    end
+
+    class BelongsToReflection < AssociationReflection
+      def association_primary_key(klass = nil)
+        if primary_key = options[:primary_key]
+          # CPK
+          # @association_primary_key ||= -primary_key.to_s
+          @association_primary_key ||= primary_key.freeze
+        else
+          primary_key(klass || self.klass)
+        end
+      end
+    end
+
+    class ThroughReflection < AbstractReflection #:nodoc:
+      def association_primary_key(klass = nil)
+        # Get the "actual" source reflection if the immediate source reflection has a
+        # source reflection itself
+        if primary_key = actual_source_reflection.options[:primary_key]
+          # CPK
+          # @association_primary_key ||= -primary_key.to_s
+          @association_primary_key ||= primary_key.freeze
+        else
+          primary_key(klass || self.klass)
+        end
       end
     end
   end

--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -25,13 +25,15 @@ module ActiveRecord
       end
 
       stmt = Arel::UpdateManager.new
+      stmt.table(arel.join_sources.empty? ? table : arel.source)
+      stmt.key = table[primary_key]
+
       # CPK
-      if @klass.composite?
+      if @klass.composite? && stmt.to_sql =~ /['"]#{primary_key.to_s}['"]/
+        stmt = Arel::UpdateManager.new
         stmt.table(arel_table)
         cpk_subquery(stmt)
       else
-        stmt.table(arel.join_sources.empty? ? table : arel.source)
-        stmt.key = arel_attribute(primary_key)
         stmt.wheres = arel.constraints
       end
       stmt.take(arel.limit)
@@ -42,7 +44,7 @@ module ActiveRecord
         if klass.locking_enabled? &&
             !updates.key?(klass.locking_column) &&
             !updates.key?(klass.locking_column.to_sym)
-          attr = arel_attribute(klass.locking_column)
+          attr = table[klass.locking_column]
           updates[attr.name] = _increment_attribute(attr)
         end
         stmt.set _substitute_values(updates)
@@ -68,13 +70,15 @@ module ActiveRecord
       end
 
       stmt = Arel::DeleteManager.new
+      stmt.from(arel.join_sources.empty? ? table : arel.source)
+      stmt.key = table[primary_key]
 
-      if @klass.composite?
+      # CPK
+      if @klass.composite? && stmt.to_sql =~ /['"]#{primary_key.to_s}['"]/
+        stmt = Arel::DeleteManager.new
         stmt.from(arel_table)
         cpk_subquery(stmt)
       else
-        stmt.from(arel.join_sources.empty? ? table : arel.source)
-        stmt.key = arel_attribute(primary_key)
         stmt.wheres = arel.constraints
       end
 
@@ -138,7 +142,7 @@ module ActiveRecord
     #        reference_codes.reference_code = cpk_child.reference_code)
     def cpk_exists_subquery(stmt)
       arel_attributes = primary_keys.map do |key|
-        arel_attribute(key)
+        table[key]
       end.to_composite_keys
 
       # Clone the query
@@ -173,7 +177,7 @@ module ActiveRecord
     #         FROM `reference_codes`) __active_record_temp)
     def cpk_mysql_subquery(stmt)
       arel_attributes = primary_keys.map do |key|
-        arel_attribute(key)
+        table[key]
       end.to_composite_keys
 
       subselect = arel.clone

--- a/lib/composite_primary_keys/relation/calculations.rb
+++ b/lib/composite_primary_keys/relation/calculations.rb
@@ -4,11 +4,12 @@ module CompositePrimaryKeys
       def aggregate_column(column_name)
         # CPK
         if column_name.kind_of?(Array)
+          # Note: Test don't seem to run this code?
           column_name.map do |column|
-            @klass.arel_attribute(column_name)
+            @klass.arel_table[column]
           end
         elsif @klass.has_attribute?(column_name) || @klass.attribute_alias?(column_name)
-          @klass.arel_attribute(column_name)
+          @klass.arel_table[column_name]
         else
           Arel.sql(column_name == :all ? "*" : column_name.to_s)
         end
@@ -31,38 +32,33 @@ module CompositePrimaryKeys
           relation = unscope(:order).distinct!(false)
 
           column = aggregate_column(column_name)
-
           select_value = operation_over_aggregate_column(column, operation, distinct)
-          if operation == "sum" && distinct
-            select_value.distinct = true
-          end
+          select_value.distinct = true if operation == "sum" && distinct
 
-          column_alias = select_value.alias
-          column_alias ||= @klass.connection.column_name_for_operation(operation, select_value)
           relation.select_values = [select_value]
 
           query_builder = relation.arel
         end
 
-        result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder, nil) }
-        row    = result.first
-        value  = row && row.values.first
-        type   = result.column_types.fetch(column_alias) do
-          type_for(column_name)
-        end
+        result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder) }
 
-        type_cast_calculated_value(value, type, operation)
+        type_cast_calculated_value(result.cast_values.first, operation) do |value|
+          type = column.try(:type_caster) ||
+            # CPK
+            # lookup_cast_type_from_join_dependencies(column_name.to_s) || Type.default_value
+            lookup_cast_type_from_join_dependencies(column_name.to_s) || ::ActiveRecord::Type.default_value
+          type.deserialize(value)
+        end
       end
 
       def build_count_subquery(relation, column_name, distinct)
         if column_name == :all
+          column_alias = Arel.star
+          # CPK
+          # relation.select_values = [ Arel.sql(FinderMethods::ONE_AS_ONE) ] unless distinct
           relation.select_values = [ Arel.sql(::ActiveRecord::FinderMethods::ONE_AS_ONE) ] unless distinct
-          if relation.select_values.first.is_a?(Array)
-            relation.select_values = relation.select_values.first.map do |column|
-              Arel::Attribute.new(@klass.unscoped.table, column)
-            end
-          end
         elsif column_name.is_a?(Array)
+          column_alias = Arel.star
           relation.select_values = column_name.map do |column|
             Arel::Attribute.new(@klass.unscoped.table, column)
           end
@@ -71,10 +67,37 @@ module CompositePrimaryKeys
           relation.select_values = [ aggregate_column(column_name).as(column_alias) ]
         end
 
-        subquery = relation.arel.as(Arel.sql("subquery_for_count"))
-        select_value = operation_over_aggregate_column(column_alias || Arel.star, "count", false)
+        subquery_alias = Arel.sql("subquery_for_count")
+        select_value = operation_over_aggregate_column(column_alias, "count", false)
 
-        Arel::SelectManager.new(subquery).project(select_value)
+        relation.build_subquery(subquery_alias, select_value)
+      end
+
+      def calculate(operation, column_name)
+        if has_include?(column_name)
+          relation = apply_join_dependency
+
+          if operation.to_s.downcase == "count"
+            unless distinct_value || distinct_select?(column_name || select_for_count)
+              relation.distinct!
+              # CPK
+              # relation.select_values = [ klass.primary_key || table[Arel.star] ]
+              if klass.primary_key.present? && klass.primary_key.is_a?(Array)
+                relation.select_values = klass.primary_key.map do |k|
+                  "#{connection.quote_table_name(klass.table_name)}.#{connection.quote_column_name(k)}"
+                end
+              else
+                relation.select_values = [ klass.primary_key || table[Arel.star] ]
+              end
+            end
+            # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
+            relation.order_values = [] if group_values.empty?
+          end
+
+          relation.calculate(operation, column_name)
+        else
+          perform_calculation(operation, column_name)
+        end
       end
     end
   end

--- a/lib/composite_primary_keys/relation/finder_methods.rb
+++ b/lib/composite_primary_keys/relation/finder_methods.rb
@@ -26,12 +26,12 @@ module CompositePrimaryKeys
       def limited_ids_for(relation)
         # CPK
         # values = @klass.connection.columns_for_distinct(
-        #     connection.column_name_from_arel_node(arel_attribute(primary_key)),
+        #     connection.column_name_from_arel_node(table[primary_key]),
         #     relation.order_values
         # )
 
         columns = @klass.primary_keys.map do |key|
-          connection.visitor.compile(arel_attribute(key))
+          connection.visitor.compile(table[key])
         end
         values = @klass.connection.columns_for_distinct(columns, relation.order_values)
 
@@ -110,12 +110,12 @@ module CompositePrimaryKeys
       #
       #   result = limit(limit || 1)
       #   # CPK
-      #   # result.order!(arel_attribute(primary_key)) if order_values.empty? && primary_key
+      #   # result.order!(table[primary_key]) if order_values.empty? && primary_key
       #   if order_values.empty? && primary_key
       #     if composite?
-      #       result.order!(primary_keys.map { |pk| arel_attribute(pk).asc })
+      #       result.order!(primary_keys.map { |pk| table[pk].asc })
       #     elsif
-      #       result.order!(arel_attribute(primary_key))
+      #       result.order!(table[primary_key])
       #     end
       #   end
       #
@@ -224,8 +224,8 @@ module CompositePrimaryKeys
       def ordered_relation
         if order_values.empty? && (implicit_order_column || primary_key)
           # CPK
-          # order(arel_attribute(implicit_order_column || primary_key).asc)
-          order(Array(implicit_order_column || primary_key).map {|key| arel_attribute(key).asc})
+          # order(table[implicit_order_column || primary_key].asc)
+          order(Array(implicit_order_column || primary_key).map {|key| table[key].asc})
         else
           self
         end

--- a/lib/composite_primary_keys/relation/predicate_builder/association_query_value.rb
+++ b/lib/composite_primary_keys/relation/predicate_builder/association_query_value.rb
@@ -3,16 +3,33 @@ module ActiveRecord
     class AssociationQueryValue
       def queries
         # CPK
-        if associated_table.association_join_foreign_key.is_a?(Array)
+        if associated_table.join_foreign_key.is_a?(Array)
           if ids.is_a?(ActiveRecord::Relation)
             ids.map do |id|
-              associated_table.association_join_foreign_key.zip(id.id).to_h
+              associated_table.join_foreign_key.zip(id.id).to_h
             end
           else
-            [associated_table.association_join_foreign_key.zip(ids).to_h]
+            [associated_table.join_foreign_key.zip(ids).to_h]
           end
         else
-          [associated_table.association_join_foreign_key.to_s => ids]
+          [associated_table.join_foreign_key => ids]
+        end
+      end
+
+      def ids
+        case value
+        when Relation
+          value.select_values.empty? ? value.select(primary_key) : value
+        when Array
+          value.map { |v| convert_to_id(v) }
+        else
+          # CPK
+          # convert_to_id(value)
+          if value.composite?
+            value.class.primary_keys.zip(value.id)
+          else
+            convert_to_id(value)
+          end
         end
       end
     end

--- a/lib/composite_primary_keys/relation/query_methods.rb
+++ b/lib/composite_primary_keys/relation/query_methods.rb
@@ -4,12 +4,12 @@ module CompositePrimaryKeys
       def reverse_sql_order(order_query)
         if order_query.empty?
           # CPK
-          # return [arel_attribute(primary_key).desc] if primary_key
+          # return [table[primary_key].desc] if primary_key
 
           if primary_key
             # break apart CPKs
             return primary_key.map do |key|
-              arel_attribute(key).desc
+              table[key].desc
             end
           else
             raise IrreversibleOrderError,

--- a/lib/composite_primary_keys/relation/where_clause.rb
+++ b/lib/composite_primary_keys/relation/where_clause.rb
@@ -1,23 +1,18 @@
 module ActiveRecord
   class Relation
     class WhereClause
-      def to_h(table_name = nil)
-        equalities = equalities(predicates)
+      def to_h(table_name = nil, equality_only: false)
+        equalities = equalities(predicates, equality_only)
 
         # CPK Adds this line, because ours are coming in with AND->{EQUALITY, EQUALITY}
         equalities = predicates.grep(Arel::Nodes::And).map(&:children).flatten.grep(Arel::Nodes::Equality) if equalities.empty?
 
-        if table_name
-          equalities = equalities.select do |node|
-            node.left.relation.name == table_name
-          end
-        end
-
-        equalities.map { |node|
+        equalities.each_with_object({}) do |node, hash|
+          next if table_name&.!= node.left.relation.name
           name = node.left.name.to_s
           value = extract_node_value(node.right)
-          [name, value]
-        }.to_h
+          hash[name] = value
+        end
       end
     end
   end

--- a/lib/composite_primary_keys/table_metadata.rb
+++ b/lib/composite_primary_keys/table_metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class TableMetadata # :nodoc:
+    def associated_with?(table_name)
+      # CPK
+      # klass&._reflect_on_association(table_name) || klass&._reflect_on_association(table_name.singularize)
+      klass&._reflect_on_association(table_name) || klass&._reflect_on_association(table_name.to_s.singularize)
+    end
+  end
+end

--- a/lib/composite_primary_keys/version.rb
+++ b/lib/composite_primary_keys/version.rb
@@ -1,8 +1,8 @@
 module CompositePrimaryKeys
   module VERSION
-    MAJOR = 12
+    MAJOR = 13
     MINOR = 0
-    TINY  = 8
+    TINY  = 0
     STRING = [MAJOR, MINOR, TINY].join('.')
   end
 end

--- a/test/fixtures/departments.yml
+++ b/test/fixtures/departments.yml
@@ -13,3 +13,7 @@ human_resources:
 offsite_accounting:
   id: 1
   location_id: 2
+
+offsite_engineering:
+  id: 2
+  location_id: 2

--- a/test/fixtures/employees.yml
+++ b/test/fixtures/employees.yml
@@ -26,3 +26,8 @@ mindy:
   department_id: 3
   location_id: 2
   name: Mindy
+
+casey:
+  department_id: 2
+  location_id: 2
+  name: Casey

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -2,28 +2,32 @@ require File.expand_path('../abstract_unit', __FILE__)
 
 class TestAttributes < ActiveSupport::TestCase
   fixtures :reference_types, :reference_codes, :products, :tariffs, :product_tariffs
-  
+
   CLASSES = {
     :single => {
       :class => ReferenceType,
       :primary_keys => :reference_type_id,
     },
-    :dual   => { 
+    :dual   => {
       :class => ReferenceCode,
       :primary_keys => [:reference_type_id, :reference_code],
     },
   }
-  
+
   def setup
     self.class.classes = CLASSES
   end
-  
+
   def test_brackets
+    tested_at_least_on_attribute = false
     testing_with do
       @first.attributes.each_pair do |attr_name, value|
+        next if value.nil?
         assert_equal value, @first[attr_name]
+        tested_at_least_on_attribute = true
       end
     end
+    assert tested_at_least_on_attribute
   end
 
   def test_brackets_primary_key

--- a/test/test_calculations.rb
+++ b/test/test_calculations.rb
@@ -3,7 +3,7 @@ require File.expand_path('../abstract_unit', __FILE__)
 class TestCalculations < ActiveSupport::TestCase
   fixtures :articles, :products, :tariffs, :product_tariffs, :suburbs, :streets, :restaurants,
            :dorms, :rooms, :room_attributes, :room_attribute_assignments, :students, :room_assignments, :users, :readings,
-           :departments, :employees, :memberships, :membership_statuses
+           :departments, :employees, :memberships, :membership_statuses, :reference_codes, :reference_types
 
   def test_count
     assert_equal(3, Product.includes(:product_tariffs).count)
@@ -19,7 +19,14 @@ class TestCalculations < ActiveSupport::TestCase
     product = products(:first_product)
     assert_equal(1, product.product_tariffs.select('tariff_start_date').distinct.count)
   end
-  
+
+  def test_count_on_joined_relations_that_have_column_names_in_common
+    count_without_includes = ReferenceCode.count
+    count_with_includes  = ReferenceCode.includes(:reference_type).references(:reference_type).count
+    assert_equal(count_without_includes, count_with_includes)
+    assert_equal(5, count_with_includes)
+  end
+
   def test_count_not_distinct
     product = products(:first_product)
     assert_equal(2, product.product_tariffs.select('tariff_start_date').count)

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -31,13 +31,13 @@ class TestDelete < ActiveSupport::TestCase
   def test_delete_all_with_join
     employee = employees(:mindy)
 
-    assert_equal(4, Department.count)
+    assert_equal(5, Department.count)
 
     Department.joins(:employees).
                where('employees.name = ?', employee.name).
                delete_all
 
-    assert_equal(3, Department.count)
+    assert_equal(4, Department.count)
   end
 
   def test_clear_association

--- a/test/test_find.rb
+++ b/test/test_find.rb
@@ -129,13 +129,19 @@ class TestFind < ActiveSupport::TestCase
   def test_find_by_all_associations
     departments = Department.all
     employees = Employee.where(:department => departments)
-    assert_equal(5, employees.to_a.count)
+    assert_equal(6, employees.to_a.count)
+  end
+
+  def test_find_by_some_associations
+    departments = Department.where(location_id: 1)
+    employees = Employee.where(:department => departments)
+    assert_equal(4, employees.to_a.count)
   end
 
   def test_expand_all
     departments = Department.all
     employees = Employee.where(:department => departments)
-    assert_equal(5, employees.count)
+    assert_equal(6, employees.count)
   end
 
   def test_find_one_with_params_id


### PR DESCRIPTION
- [x] Run tests against Rails 6.1.0.rc1
- [x] Get my app booting
- [x] Fix a few CPK tests but 100+ remain broken

Figured I'd share that in case anyone else is looking to start working on this too. 

Other things to do:

- [x] Get running through a few smoke tests in my app
- [x] Get tests passing in CPK
- [x] Get tests passing in my app
- [x] Review `# CPK` code to see if those methods still exist or need to change based on new Rails 
- [x] Review https://github.com/composite-primary-keys/composite_primary_keys/pull/504 to see if it is still an issue after the other updates being made
- [x] Get the Travis CI build passing
- [x] Fix deprecation warnings
- [x] I have an error in my app when doing `includes(...).references(...)` where Rails adds in its mapping: `` `students`.`id,district_id` AS t0_r0``. In my case I could easily fix to do `joins` instead, but it worries me that there is somewhere in here we are not correctly giving rails the column name. 
- [x] double check `#find_each` works. In my Rails 6.0 app, it stops processing after the first batch.