### PR TITLE
Stay compatible with ruby 2.6 and below

### DIFF
--- a/lib/composite_primary_keys/connection_adapters/mysql/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/mysql/database_statements.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           # CPK
           if pk.is_a?(Array)
             pk.map do |key|
-              column = self.column_for(arel.ast.relation.name, key)
+              column = column_for(arel.ast.relation.name, key)
               column.auto_increment? ? last_inserted_id(value) : nil
             end
           else


### PR DESCRIPTION
Calling a private method with `self` receiver is supported from ruby 2.7.

In ruby 2.6 it resolves a below error,

```
NoMethodError: private method `column_for' called for #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x000055bd449c00e8>
```

refs
- https://github.com/ruby/ruby/pull/2474
- https://bugs.ruby-lang.org/issues/11297
- https://bugs.ruby-lang.org/issues/16123