### PR TITLE
Use original implementation to execute COUNT without subquery.

### DIFF
--- a/lib/composite_primary_keys/relation/calculations.rb
+++ b/lib/composite_primary_keys/relation/calculations.rb
@@ -14,46 +14,6 @@ module CompositePrimaryKeys
         end
       end
 
-      def execute_simple_calculation(operation, column_name, distinct) #:nodoc:
-        column_alias = column_name
-
-        # CPK
-        # if operation == "count" && (column_name == :all && distinct || has_limit_or_offset?)
-        #   # Shortcut when limit is zero.
-        #   return 0 if limit_value == 0
-        #
-        #   query_builder = build_count_subquery(spawn, column_name, distinct)
-        if operation == "count"
-          relation = unscope(:order)
-          query_builder = build_count_subquery(spawn, column_name, distinct)
-        else
-          # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
-          relation = unscope(:order).distinct!(false)
-
-          column = aggregate_column(column_name)
-
-          select_value = operation_over_aggregate_column(column, operation, distinct)
-          if operation == "sum" && distinct
-            select_value.distinct = true
-          end
-
-          column_alias = select_value.alias
-          column_alias ||= @klass.connection.column_name_for_operation(operation, select_value)
-          relation.select_values = [select_value]
-
-          query_builder = relation.arel
-        end
-
-        result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder, nil) }
-        row    = result.first
-        value  = row && row.values.first
-        type   = result.column_types.fetch(column_alias) do
-          type_for(column_name)
-        end
-
-        type_cast_calculated_value(value, type, operation)
-      end
-
       def build_count_subquery(relation, column_name, distinct)
         if column_name == :all
           relation.select_values = [ Arel.sql(::ActiveRecord::FinderMethods::ONE_AS_ONE) ] unless distinct


### PR DESCRIPTION
When operation like followings, CPK generates subquery always.
And I don't think `ActiveRecord::Calculations#execute_simple_calculation` needs CPK specific implementation.
So I stop to overwrite this.
And I also don't think overwriting this need on master too. If this PR can merge.  I'll create same PR to master

```
User.count(:id)
```

```
SELECT COUNT(count_column) FROM (SELECT `users`.`id` AS count_column FROM `users`) subquery_for_count
```