### PR TITLE
Fix #551 and Fix #554

### DIFF
--- a/lib/composite_primary_keys/relation/predicate_builder/association_query_value.rb
+++ b/lib/composite_primary_keys/relation/predicate_builder/association_query_value.rb
@@ -27,7 +27,7 @@ module ActiveRecord
           # convert_to_id(value)
           if value.nil?
             nil
-          elsif value.composite?
+          elsif value.respond_to?(:composite?) && value.composite?
             value.class.primary_keys.zip(value.id)
           else
             convert_to_id(value)

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -355,4 +355,10 @@ class TestAssociations < ActiveSupport::TestCase
     article.reading_ids = Reading.pluck(:id)
     assert_equal article.reading_ids, Reading.pluck(:id)
   end
+
+  def test_find_by_association
+    assert_equal Membership.where(user: '1').count, 1
+    assert_equal Membership.where(user_id: '1').count, 1
+    assert_equal Membership.where(user: User.find(1)).count, 1
+  end
 end


### PR DESCRIPTION
There was an issue when using the association name as a query param but only including its ID as the value, rather than an AR object

@mihaijurca and @LyricL-Gitster and @stevehill1981 if you all wanna check this out. 

@cfis if looks good to you, will you merge? 