### PR TITLE
Fix unintentional connection to database

### DIFF
--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       stmt.key = table[primary_key]
 
       # CPK
-      if @klass.composite? && stmt.to_sql =~ /['"]#{primary_key.to_s}['"]/
+      if @klass.composite? && @klass.connection.visitor.compile(stmt.ast) =~ /['"]#{primary_key.to_s}['"]/
         stmt = Arel::UpdateManager.new
         stmt.table(arel_table)
         cpk_subquery(stmt)
@@ -74,7 +74,7 @@ module ActiveRecord
       stmt.key = table[primary_key]
 
       # CPK
-      if @klass.composite? && stmt.to_sql =~ /['"]#{primary_key.to_s}['"]/
+      if @klass.composite? && @klass.connection.visitor.compile(stmt.ast) =~ /['"]#{primary_key.to_s}['"]/
         stmt = Arel::DeleteManager.new
         stmt.from(arel_table)
         cpk_subquery(stmt)

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -31,6 +31,8 @@ class TestDelete < ActiveSupport::TestCase
   end
 
   def test_delete_all_with_join
+    tested_delete_all = false
+    Arel::Table.engine = nil # should not rely on the global Arel::Table.engine
     employee = employees(:mindy)
 
     assert_equal(5, Department.count)
@@ -41,6 +43,10 @@ class TestDelete < ActiveSupport::TestCase
 
     assert_equal(4, Department.count)
     assert_equal(1, deleted)
+    tested_delete_all = true
+  ensure
+    Arel::Table.engine = ActiveRecord::Base
+    assert tested_delete_all
   end
 
   def test_clear_association

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -74,6 +74,8 @@ class TestUpdate < ActiveSupport::TestCase
   end
 
   def test_update_all_join
+    tested_update_all = false
+    Arel::Table.engine = nil # should not rely on the global Arel::Table.engine
     ReferenceCode.joins(:reference_type).
                   where('reference_types.reference_type_id = ?', 2).
                   update_all(:description => 'random value')
@@ -82,6 +84,10 @@ class TestUpdate < ActiveSupport::TestCase
                           where(:description => 'random value')
 
     assert_equal(2, query.count)
+    tested_update_all = true
+  ensure
+    Arel::Table.engine = ActiveRecord::Base
+    assert tested_update_all
   end
 
   def test_update_with_uniqueness


### PR DESCRIPTION
When target model connecion is different from ActiveRecord::Base.connection, 
delete_all and update_all raise error.

```
5: from activerecord-6.1.3.2/lib/active_record/querying.rb:22:in `delete_all'
4: from composite_primary_keys-13.0.0/lib/composite_primary_keys/relation.rb:77:in `delete_all'
3: from activerecord-6.1.3.2/lib/arel/tree_manager.rb:55:in `to_sql'
2: from activerecord-6.1.3.2/lib/active_record/connection_handling.rb:283:in `connection'
1: from activerecord-6.1.3.2/lib/active_record/connection_handling.rb:327:in `retrieve_connection'
activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:1125:in `retrieve_connection': No connection pool for 'ActiveRecord::Base' found. (ActiveRecord::ConnectionNotEstablished)
```

## Reproduction

https://github.com/kmasuda-aiming/composite-primary-keys-557

## Similar commits on rails

https://github.com/rails/rails/commit/bc99e4014f61f20df966c40a2c2a1bffb3885fce