### PR TITLE
add scoped association test

### DIFF
--- a/lib/composite_primary_keys/associations/join_dependency.rb
+++ b/lib/composite_primary_keys/associations/join_dependency.rb
@@ -2,23 +2,23 @@ module ActiveRecord
   module Associations
     class JoinDependency
 
-      class JoinAssociation < JoinPart # :nodoc:
-        private
-          def append_constraints(join, constraints)
-            if join.is_a?(Arel::Nodes::StringJoin)
-              join_string = Arel::Nodes::And.new(constraints.unshift join.left)
-              join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
-            else
-              right = join.right
-              # CPK
-              if right.expr.children.empty?
-                right.expr = Arel::Nodes::And.new(constraints)
-              else
-                right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)
-              end
-            end
-          end
-      end
+      # class JoinAssociation < JoinPart # :nodoc:
+      #   private
+      #     def append_constraints(join, constraints)
+      #       if join.is_a?(Arel::Nodes::StringJoin)
+      #         join_string = Arel::Nodes::And.new(constraints.unshift join.left)
+      #         join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
+      #       else
+      #         right = join.right
+      #         # CPK
+      #         if right.expr.children.empty?
+      #           right.expr = Arel::Nodes::And.new(constraints)
+      #         else
+      #           right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)
+      #         end
+      #       end
+      #     end
+      # end
 
       class Aliases # :nodoc:
         def column_alias(node, column)

--- a/lib/composite_primary_keys/associations/join_dependency.rb
+++ b/lib/composite_primary_keys/associations/join_dependency.rb
@@ -2,23 +2,23 @@ module ActiveRecord
   module Associations
     class JoinDependency
 
-      # class JoinAssociation < JoinPart # :nodoc:
-      #   private
-      #     def append_constraints(join, constraints)
-      #       if join.is_a?(Arel::Nodes::StringJoin)
-      #         join_string = Arel::Nodes::And.new(constraints.unshift join.left)
-      #         join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
-      #       else
-      #         right = join.right
-      #         # CPK
-      #         if right.expr.children.empty?
-      #           right.expr = Arel::Nodes::And.new(constraints)
-      #         else
-      #           right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)
-      #         end
-      #       end
-      #     end
-      # end
+      class JoinAssociation < JoinPart # :nodoc:
+        private
+          def append_constraints(join, constraints)
+            if join.is_a?(Arel::Nodes::StringJoin)
+              join_string = Arel::Nodes::And.new(constraints.unshift join.left)
+              join.left = Arel.sql(base_klass.connection.visitor.compile(join_string))
+            else
+              right = join.right
+              # CPK
+              if right.expr.children.empty?
+                right.expr = Arel::Nodes::And.new(constraints)
+              else
+                right.expr = Arel::Nodes::And.new(constraints.unshift right.expr)
+              end
+            end
+          end
+      end
 
       class Aliases # :nodoc:
         def column_alias(node, column)

--- a/test/fixtures/membership.rb
+++ b/test/fixtures/membership.rb
@@ -3,7 +3,7 @@ class Membership < ActiveRecord::Base
   belongs_to :user
 	belongs_to :group
 	has_many :statuses, :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
-  has_many :active_statuses, -> { where(membership_statuses: { status: "Active"}) },
+  has_many :active_statuses, -> { where('membership_statuses.status = ?', 'Active') },
            :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
   has_many :readings, :primary_key => :user_id, :foreign_key => :user_id
 end

--- a/test/fixtures/membership.rb
+++ b/test/fixtures/membership.rb
@@ -3,5 +3,7 @@ class Membership < ActiveRecord::Base
   belongs_to :user
 	belongs_to :group
 	has_many :statuses, :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
+  has_many :active_statuses, -> { where(membership_status: { status: "Active"}) },
+           :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
   has_many :readings, :primary_key => :user_id, :foreign_key => :user_id
 end

--- a/test/fixtures/membership.rb
+++ b/test/fixtures/membership.rb
@@ -3,7 +3,7 @@ class Membership < ActiveRecord::Base
   belongs_to :user
 	belongs_to :group
 	has_many :statuses, :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
-  has_many :active_statuses, -> { where(membership_status: { status: "Active"}) },
+  has_many :active_statuses, -> { where(membership_statuses: { status: "Active"}) },
            :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
   has_many :readings, :primary_key => :user_id, :foreign_key => :user_id
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -344,9 +344,11 @@ class TestAssociations < ActiveSupport::TestCase
   end
 
   def test_scoped_has_many_with_primary_key_with_associations
+    puts "TO_SQL"
     puts Membership.joins(:active_statuses).to_sql
     memberships = Membership.joins(:active_statuses)
     assert_equal(2, memberships.length)
+
     assert_equal([1,1], memberships[0].id)
     assert_equal([3,2], memberships[1].id)
   end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -343,6 +343,13 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal([3,2], memberships[1].id)
   end
 
+  def test_scoped_has_many_with_primary_key_with_associations
+    memberships = Membership.includes(:active_statuses).references(:membership_statuses)
+    assert_equal(2, memberships.length)
+    assert_equal([1,1], memberships[0].id)
+    assert_equal([3,2], memberships[1].id)
+  end
+
   def test_foreign_key_present_with_null_association_ids
     group = Group.new
     group.memberships.build

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -344,8 +344,8 @@ class TestAssociations < ActiveSupport::TestCase
   end
 
   def test_scoped_has_many_with_primary_key_with_associations
-    puts Membership.includes(:active_statuses).references(:membership_statuses).to_sql
-    memberships = Membership.includes(:active_statuses).references(:membership_statuses)
+    puts Membership.joins(:active_statuses).to_sql
+    memberships = Membership.joins(:active_statuses)
     assert_equal(2, memberships.length)
     assert_equal([1,1], memberships[0].id)
     assert_equal([3,2], memberships[1].id)

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -344,6 +344,7 @@ class TestAssociations < ActiveSupport::TestCase
   end
 
   def test_scoped_has_many_with_primary_key_with_associations
+    puts Membership.includes(:active_statuses).references(:membership_statuses).to_sql
     memberships = Membership.includes(:active_statuses).references(:membership_statuses)
     assert_equal(2, memberships.length)
     assert_equal([1,1], memberships[0].id)


### PR DESCRIPTION
I'm having a MariaDB SQL generation problem where my scoped association with composite primary keys gets generated with SQL like:

```
FROM `table1` INNER JOIN `table2` ON  AND
```

ON and AND are not supposed to be next to one another.

I'm trying to make a test case that uncovers this. I haven't figured out how to run the tests locally, so I'm making this draft PR to try to use GitHub actions to run my test.