### PR TITLE
fix scoped associations

### DIFF
--- a/test/fixtures/membership.rb
+++ b/test/fixtures/membership.rb
@@ -3,5 +3,7 @@ class Membership < ActiveRecord::Base
   belongs_to :user
 	belongs_to :group
 	has_many :statuses, :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
+  has_many :active_statuses, -> { where('membership_statuses.status = ?', 'Active') },
+           :class_name => 'MembershipStatus', :foreign_key => [:user_id, :group_id]
   has_many :readings, :primary_key => :user_id, :foreign_key => :user_id
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -343,6 +343,14 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal([3,2], memberships[1].id)
   end
 
+  def test_scoped_has_many_with_primary_key_with_associations
+    memberships = Membership.joins(:active_statuses)
+    assert_equal(2, memberships.length)
+
+    assert_equal([1,1], memberships[0].id)
+    assert_equal([3,2], memberships[1].id)
+  end
+
   def test_foreign_key_present_with_null_association_ids
     group = Group.new
     group.memberships.build


### PR DESCRIPTION
Continuation of #560.

There is an SQL generation problem where a scoped association with
composite primary keys gets generated with SQL like:

```
FROM `table1` INNER JOIN `table2` ON  AND
```

ON and AND are not supposed to be next to one another.

This adds a test to uncover the issue, and then fixes it with a patch.

The problem seems to be that `append_constraints` assumes that `right.expr` is non-empty, but in the case of CPK it is sometimes empty, presumably because id constraints have been removed.

Tests passing here: https://github.com/ryantm/composite_primary_keys/pull/2/checks