### PR TITLE
Follow the method name change in ActiveRecord 7.0.2

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 2.7.0'
-  s.add_dependency('activerecord', '~> 7.0.0')
+  s.add_dependency('activerecord', '~> 7.0.2')
   s.add_development_dependency('rake')
 end

--- a/lib/composite_primary_keys/autosave_association.rb
+++ b/lib/composite_primary_keys/autosave_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           #key = reflection.options[:primary_key] ? send(reflection.options[:primary_key]) : id
           key = reflection.options[:primary_key] ? self[reflection.options[:primary_key]] : id
 
-          if (autosave && record.changed_for_autosave?) || new_record? || record_changed?(reflection, record, key)
+          if (autosave && record.changed_for_autosave?) || new_record? || _record_changed?(reflection, record, key)
             unless reflection.through_reflection
               record[reflection.foreign_key] = key
               if inverse_reflection = reflection.inverse_of

--- a/test/fixtures/department.rb
+++ b/test/fixtures/department.rb
@@ -13,4 +13,8 @@ class Department < ActiveRecord::Base
                  :primary_key =>  [:id, :location_id],
                  :foreign_key => [:department_id, :location_id]
 
+  has_one :head_without_autosave, :class_name => 'Employee',
+          # We intentionally redefine primary key for test purposes. #455
+          :primary_key =>  [:id, :location_id],
+          :foreign_key => [:department_id, :location_id]
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -124,6 +124,15 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal('Sarah1', department.head.name)
   end
 
+  def test_has_no_autosave
+    department = departments(:engineering)
+    assert_equal('Sarah', department.head_without_autosave.name)
+
+    department.head_without_autosave.name = 'Sarah1'
+    department.save!
+    assert_equal('Sarah1', department.head_without_autosave.name)
+  end
+
   def test_has_many_association_is_not_cached_to_where_it_returns_the_wrong_ones
     engineering = departments(:engineering)
     engineering_employees = engineering.employees


### PR DESCRIPTION
Fixed undefined_method error since `record_changed?` has been renamed to `_record_changed?` in ActiveRecord 7.0.2

follow this change: https://github.com/rails/rails/pull/44191