### PR TITLE
Make CompositeKeys respond to #to_param consistently with ActiveRecord::Base

### DIFF
--- a/lib/composite_primary_keys/composite_arrays.rb
+++ b/lib/composite_primary_keys/composite_arrays.rb
@@ -53,6 +53,8 @@ module CompositePrimaryKeys
       # Doing this makes it easier to parse Base#[](attr_name)
       map { |key| Utils.escape_string_key(key.to_s) }.join(ID_SEP)
     end
+
+    alias_method :to_param, :to_s
   end
 
   module Utils

--- a/test/test_composite_arrays.rb
+++ b/test/test_composite_arrays.rb
@@ -35,4 +35,10 @@ class CompositeArraysTest < ActiveSupport::TestCase
     assert_equal 'The USA,^5EWashington^2C D.C.',
                  CompositePrimaryKeys::CompositeKeys.new(['The USA', '^Washington, D.C.']).to_s
   end
+
+  def test_to_param
+    assert_equal '1,2', CompositePrimaryKeys::CompositeKeys.new([1, 2]).to_param
+    assert_equal 'The USA,^5EWashington^2C D.C.',
+                 CompositePrimaryKeys::CompositeKeys.new(['The USA', '^Washington, D.C.']).to_param
+  end
 end


### PR DESCRIPTION
Suppose you have a route like this.

```ruby
get '/friendships/:id', to: 'friendships#show', as: 'friendship'
```

On generating a path using the Rails routing method, passing the model instance works perfectly:

```ruby
app.friendship_path(Friendship.first)
=> "/friendships/1,30"
```

but using the id explicitly produces a different outcome.

```ruby
app.friendship_path(id: Friendship.first.id)
=> "/friendships/1%2F30"
```

This is because `CompositePrimaryKeys::CompositeKeys` inherits from `Array`, and it has [its own `#to_param` in `active_support/core_ext`](https://github.com/rails/rails/blob/8d34f769ceeac75602ef08a5b55f6ea305184f46/activesupport/lib/active_support/core_ext/object/to_query.rb#L42-L44).

This isn't good for us, because the path changes based on how they were generated and can't be treated uniformly. So my proposal is to add `#to_param` into `CompositePrimaryKeys::CompositeKeys` which behaves same as `#to_s`.

Any suggestions would be appreciated, thanks!