### PR TITLE
Accept strings in has_many ids assignment

### DIFF
--- a/lib/composite_primary_keys/associations/collection_association.rb
+++ b/lib/composite_primary_keys/associations/collection_association.rb
@@ -6,7 +6,7 @@ module CompositePrimaryKeys
 
       # CPK-
       if primary_key.is_a?(Array)
-        ids = CompositePrimaryKeys.normalize(ids, primary_key.size)
+        ids = ids.map { |id| CompositePrimaryKeys::CompositeKeys.parse(id) }
         primary_key.each_with_index do |key, i|
           pk_type = klass.type_for_attribute(key)
           ids.each { |id| id[i] = pk_type.cast(id[i]) }
@@ -15,7 +15,7 @@ module CompositePrimaryKeys
         predicate = CompositePrimaryKeys::Predicates.cpk_in_predicate(klass.arel_table, reflection.association_primary_key, ids)
         records = klass.where(predicate).index_by do |r|
           reflection.association_primary_key.map{ |k| r.send(k) }
-        end.values_at(*ids)
+        end.values_at(*ids).compact
       else
         pk_type = klass.type_for_attribute(primary_key)
         ids.map! { |i| pk_type.cast(i) }

--- a/lib/composite_primary_keys/associations/collection_association.rb
+++ b/lib/composite_primary_keys/associations/collection_association.rb
@@ -2,17 +2,24 @@ module CompositePrimaryKeys
   module CollectionAssociation
     def ids_writer(ids)
       primary_key = reflection.association_primary_key
-      pk_type = klass.type_for_attribute(primary_key)
       ids = Array(ids).reject(&:blank?)
-      ids.map! { |i| pk_type.cast(i) }
 
       # CPK-
       if primary_key.is_a?(Array)
+        ids = CompositePrimaryKeys.normalize(ids, primary_key.size)
+        primary_key.each_with_index do |primary_key, i|
+          pk_type = klass.type_for_attribute(primary_key)
+          ids.each { |id| id[i] = pk_type.cast(id[i]) }
+        end
+
         predicate = CompositePrimaryKeys::Predicates.cpk_in_predicate(klass.arel_table, reflection.association_primary_key, ids)
         records = klass.where(predicate).index_by do |r|
           reflection.association_primary_key.map{ |k| r.send(k) }
         end.values_at(*ids)
       else
+        pk_type = klass.type_for_attribute(primary_key)
+        ids.map! { |i| pk_type.cast(i) }
+
         records = klass.where(primary_key => ids).index_by do |r|
           r.public_send(primary_key)
         end.values_at(*ids).compact

--- a/lib/composite_primary_keys/associations/collection_association.rb
+++ b/lib/composite_primary_keys/associations/collection_association.rb
@@ -7,8 +7,8 @@ module CompositePrimaryKeys
       # CPK-
       if primary_key.is_a?(Array)
         ids = CompositePrimaryKeys.normalize(ids, primary_key.size)
-        primary_key.each_with_index do |primary_key, i|
-          pk_type = klass.type_for_attribute(primary_key)
+        primary_key.each_with_index do |key, i|
+          pk_type = klass.type_for_attribute(key)
           ids.each { |id| id[i] = pk_type.cast(id[i]) }
         end
 

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -374,6 +374,14 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal room.room_assignments.map(&:student_id), [3, 4]
   end
 
+  def test_assignment_by_ids_as_arrays_that_contains_a_comma
+    room = Room.create dorm: dorms(:branner), room_id: 4
+    e = assert_raises ActiveRecord::RecordNotFound do
+      room.room_assignment_ids = [['5,,', '5,,', '5,,']]
+    end
+    assert_match /'student_id,dorm_id,room_id'=\[\[5, 5, 5\]\]/, e.message
+  end
+
   def test_assignment_by_ids_as_strings
     room = Room.create dorm: dorms(:branner), room_id: 4
     room.room_assignment_ids = ['3,1,2', '4,1,2']

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -367,7 +367,21 @@ class TestAssociations < ActiveSupport::TestCase
     assert_equal(false, associations.send('foreign_key_present?'))
   end
 
-  def test_ids_equals_for_non_CPK_case
+  def test_assignment_by_ids_as_arrays
+    room = Room.create dorm: dorms(:branner), room_id: 4
+    room.room_assignment_ids = [[3, 1, 2], [4, 1, 2]]
+    room.save!
+    assert_equal room.room_assignments.map(&:student_id), [3, 4]
+  end
+
+  def test_assignment_by_ids_as_strings
+    room = Room.create dorm: dorms(:branner), room_id: 4
+    room.room_assignment_ids = ['3,1,2', '4,1,2']
+    room.save!
+    assert_equal room.room_assignments.map(&:student_id), [3, 4]
+  end
+
+  def test_assignment_by_ids_for_non_CPK_case
     article = Article.new
     article.reading_ids = Reading.pluck(:id)
     assert_equal article.reading_ids, Reading.pluck(:id)


### PR DESCRIPTION
In the current implementation, we can assign has_many association using composite key ids like

```ruby
room.room_assignment_ids = [[3, 1, 2], [4, 1, 2]]
```

but it doesn't accept the string representation of composite key ids.

```ruby
room.room_assignment_ids = ['3,1,2', '4,1,2']
# => NoMethodError: undefined method `zip' for "3,1,2":String
```

This PR is an attempt to add that capability, with adding some tests.
