### PR TITLE
ar_6.1.x: Fix previously_new_record? not being set to true after create

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,6 @@
+== 13.0.4
+* Fix previously_new_record? not being set to true after create
+
 == 13.0.3 (2022-01-09)
 * Remove override on ActiveRecord::Base#to_param. That method has moved to Integration
   so no longer works. #541. (Charlie Savage)

--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -73,6 +73,7 @@ module ActiveRecord
       end
 
       @new_record = false
+      @previously_new_record = true
 
       yield(self) if block_given?
 

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -31,6 +31,7 @@ class TestCreate < ActiveSupport::TestCase
       assert new_obj = @klass.create(@klass_info[:create])
       assert !new_obj.new_record?
       assert new_obj.id
+      assert new_obj.previously_new_record?
     end
   end
 


### PR DESCRIPTION
It was introduced in Rails 6.1.0, so composite-primary-keys should support it in the 13.x series.
https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/Persistence.html#method-i-previously_new_record-3F