### PR TITLE
Adds Ruby 3.2 to CI.  Updates checkout action versions.

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mariadb:
@@ -30,7 +30,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mysql:
@@ -30,7 +30,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       postgres:
@@ -28,7 +28,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -8,14 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     env:
       BUNDLE_WITHOUT: "db2 oracle sqlserver postgresql mysql"
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}


### PR DESCRIPTION
Also quotes "3.0" to avoid truncation.  An unquoted "3.0" is truncated to "3", which causes the latest Ruby 3 (at this point 3.2.0) to be loaded, which is not what's intended.

This runs green on my fork.