### PR TITLE
Improve query generation for cpk_in_predicate

### DIFF
--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -51,9 +51,43 @@ module CompositePrimaryKeys
     end
 
     def cpk_in_predicate(table, primary_keys, ids)
-      and_predicates = ids.map do |id|
-        cpk_id_predicate(table, primary_keys, id)
+      if primary_keys.length == 2
+        low_cardinality_key_part, high_cardinality_key_part = if ids.map(&:second).uniq.size > ids.map(&:first).uniq.size
+                                                                %i[first second]
+                                                              else
+                                                                %i[second first]
+                                                              end
+
+        groups = ids.group_by(&low_cardinality_key_part).transform_values do |values|
+          values.map(&high_cardinality_key_part)
+        end
+
+        and_predicates = groups.map do |low_cardinality_value, high_cardinality_values|
+          in_clause = table[primary_keys.send(high_cardinality_key_part)].in(high_cardinality_values.compact)
+          inclusion_clauses = if high_cardinality_values.include?(nil)
+                                Arel::Nodes::Grouping.new(
+                                  Arel::Nodes::Or.new(
+                                    in_clause,
+                                    table[primary_keys.send(high_cardinality_key_part)].eq(nil)
+                                  )
+                                )
+                              else
+                                in_clause
+                              end
+
+          Arel::Nodes::And.new(
+            [
+              table[primary_keys.send(low_cardinality_key_part)].eq(low_cardinality_value),
+              inclusion_clauses
+            ]
+          )
+        end
+      else
+        and_predicates = ids.map do |id|
+          cpk_id_predicate(table, primary_keys, id)
+        end
       end
+
       cpk_or_predicate(and_predicates)
     end
   end

--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -70,9 +70,9 @@ module CompositePrimaryKeys
       keys_by_first_column_name = Hash.new { |hash, key| hash[key] = [] }
       keys_by_second_column_name = Hash.new { |hash, key| hash[key] = [] }
 
-      ids.map.each do |first_column_name, second_column_name|
-        keys_by_first_column_name[first_column_name] << second_column_name
-        keys_by_second_column_name[second_column_name] << first_column_name
+      ids.map.each do |first_key_part, second_key_part|
+        keys_by_first_column_name[first_key_part] << second_key_part
+        keys_by_second_column_name[second_key_part] << first_key_part
       end
 
       low_cardinality_column_name, high_cardinality_column_name, groups = \

--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -83,8 +83,9 @@ module CompositePrimaryKeys
         end
 
       and_predicates = groups.map do |low_cardinality_value, high_cardinality_values|
-        in_clause = table[high_cardinality_column_name].in(high_cardinality_values.compact)
-        inclusion_clauses = if high_cardinality_values.include?(nil)
+        non_nil_high_cardinality_values = high_cardinality_values.compact
+        in_clause = table[high_cardinality_column_name].in(non_nil_high_cardinality_values)
+        inclusion_clauses = if non_nil_high_cardinality_values.size != high_cardinality_values.size
                               Arel::Nodes::Grouping.new(
                                 Arel::Nodes::Or.new(
                                   in_clause,

--- a/lib/composite_primary_keys/composite_predicates.rb
+++ b/lib/composite_primary_keys/composite_predicates.rb
@@ -77,9 +77,9 @@ module CompositePrimaryKeys
 
       low_cardinality_column_name, high_cardinality_column_name, groups = \
         if keys_by_first_column_name.size <= keys_by_second_column_name.size
-          primary_keys + [keys_by_first_column_name]
+          [primary_keys.first, primary_keys.second, keys_by_first_column_name]
         else
-          primary_keys.reverse + [keys_by_second_column_name]
+          [primary_keys.second, primary_keys.first, keys_by_second_column_name]
         end
 
       and_predicates = groups.map do |low_cardinality_value, high_cardinality_values|

--- a/test/test_predicates.rb
+++ b/test/test_predicates.rb
@@ -82,9 +82,6 @@ class TestPredicates < ActiveSupport::TestCase
     quoted_location_id_column = "#{connection.quote_table_name('departments')}.#{connection.quote_column_name('location_id')}"
     expected = "#{quoted_location_id_column} = 1 AND #{quoted_id_column} IN (1, 2)"
 
-    require 'byebug'
-    byebug
-
     pred = cpk_in_predicate(dep, [:id, :location_id], primary_keys)
     assert_equal(with_quoted_identifiers(expected), pred.to_sql)
   end

--- a/test/test_predicates.rb
+++ b/test/test_predicates.rb
@@ -72,6 +72,23 @@ class TestPredicates < ActiveSupport::TestCase
     assert_equal(with_quoted_identifiers(expected), pred.to_sql)
   end
 
+  def test_in_with_low_cardinality_second_key_part
+    dep = Department.arel_table
+
+    primary_keys = [[1, 1], [2, 1]]
+
+    connection = ActiveRecord::Base.connection
+    quoted_id_column = "#{connection.quote_table_name('departments')}.#{connection.quote_column_name('id')}"
+    quoted_location_id_column = "#{connection.quote_table_name('departments')}.#{connection.quote_column_name('location_id')}"
+    expected = "#{quoted_location_id_column} = 1 AND #{quoted_id_column} IN (1, 2)"
+
+    require 'byebug'
+    byebug
+
+    pred = cpk_in_predicate(dep, [:id, :location_id], primary_keys)
+    assert_equal(with_quoted_identifiers(expected), pred.to_sql)
+  end
+
   def test_in_with_nil_primary_key_part
     dep = Department.arel_table
 


### PR DESCRIPTION
Query generation for cpk_in_predicate now constructs queries in the form:

```sql
SELECT *
FROM table_name
WHERE low_cardinality_key_part = 1 AND high_cardinality_part IN (1, 2)
```

It used to generate queries in the form:

```sql
SELECT *
FROM table_name
WHERE
  (low_cardinality_key_part = 1 AND high_cardinality_part = 1)
  OR (low_cardinality_key_part = 1 AND high_cardinality_part = 2)
```

This change improves the queries by reducing the overall length of the query, especially when loading many keys. But more importantly the new query will often result in Postgres performing an `Index Scan` instead of a `Bitmap Heap Scan` (assuming the right indices have been added).