### PR TITLE
Rails 7.1 compatibility 

### DIFF
--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 2.7.0'
-  s.add_dependency('activerecord', '~> 7.0.2')
+  s.add_dependency('activerecord', '~> 7.1.0')
   s.add_development_dependency('rake')
 end

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.required_ruby_version = '>= 2.7.0'
-  s.add_dependency('activerecord', '~> 7.1.0')
+  s.add_dependency('activerecord', '~> 7.1.0.alpha')
   s.add_development_dependency('rake')
 end

--- a/lib/composite_primary_keys/connection_adapters/postgresql/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/postgresql/database_statements.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module DatabaseStatements
-        def sql_for_insert(sql, pk, binds) # :nodoc:
+        def sql_for_insert(sql, pk, binds, _returning = nil) # :nodoc:
           if pk.nil?
             # Extract the table from the insert sql. Yuck.
             table_ref = extract_table_ref_from_insert_sql(sql)

--- a/lib/composite_primary_keys/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/composite_primary_keys/connection_adapters/sqlserver/database_statements.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLServer
       module DatabaseStatements
-        def sql_for_insert(sql, pk, binds)
+        def sql_for_insert(sql, pk, binds, _returning = nil)
           if pk.nil?
             table_name = query_requires_identity_insert?(sql)
             pk = primary_key(table_name)

--- a/lib/composite_primary_keys/persistence.rb
+++ b/lib/composite_primary_keys/persistence.rb
@@ -74,8 +74,11 @@ module ActiveRecord
     def _create_record(attribute_names = self.attribute_names)
       attribute_names = attributes_for_create(attribute_names)
 
+      returning_columns_for_insert = nil
+
       new_id = self.class._insert_record(
-          attributes_with_values(attribute_names)
+          attributes_with_values(attribute_names),
+          returning_columns_for_insert
       )
 
       # CPK


### PR DESCRIPTION
Hey there 👋🏼 

First of all, thanks for the long-running support and continued maintenance of the `composite_primary_keys` gem! 🙏🏼  

While following Rails Edge in one of my apps I noticed that the pull request https://github.com/rails/rails/pull/48241 changed the method signature for `ConnectionAdapters#sql_for_insert` from three to four arguments and `Persitance#_insert_record` from one to two arguments. 

This caused applications using `composite_primary_keys` fail to boot and crash with:

```
ArgumentError: wrong number of arguments (given 4, expected 3) 
lib/composite_primary_keys/connection_adapters/postgresql/database_statements.rb:5:in 'sql_for_insert'`
```
<details>
<summary>Full Backtrace</summary>

<pre>
bundle exec rails db:setup

Created database '[project]_test'
rake aborted!
ArgumentError: wrong number of arguments (given 4, expected 3)
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/composite_primary_keys-1ffb4340bc01/lib/composite_primary_keys/connection_adapters/postgresql/database_statements.rb:5:in `sql_for_insert'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:152:in `exec_insert'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:96:in `exec_insert'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/composite_primary_keys-1ffb4340bc01/lib/composite_primary_keys/connection_adapters/abstract/database_statements.rb:6:in `insert'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in `insert'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/internal_metadata.rb:123:in `create_entry'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/internal_metadata.rb:106:in `update_or_create_entry'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/internal_metadata.rb:68:in `create_table_and_set_flags'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/schema.rb:62:in `define'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/schema.rb:50:in `define'
/home/runner/work/[project]/[project]/db/schema.rb:13:in `<top (required)>'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:358:in `load'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:358:in `load_schema'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:453:in `block (2 levels) in load_schema_current'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:501:in `block in with_temporary_connection'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:518:in `with_temporary_pool'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:500:in `with_temporary_connection'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:452:in `block in load_schema_current'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:562:in `block (2 levels) in each_current_configuration'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:559:in `each'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:559:in `block in each_current_configuration'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:558:in `each'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:558:in `each_current_configuration'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/tasks/database_tasks.rb:451:in `load_schema_current'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-48e4d99c75b7/activerecord/lib/active_record/railties/databases.rake:476:in `block (3 levels) in <top (required)>'
<internal:/opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
<internal:/opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
-e:1:in `<main>'
Tasks: TOP => db:setup => db:schema:load
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
</pre>
</details>

And

```
ArgumentError: wrong number of arguments (given 1, expected 2)
rails-99f8b049f28f/activerecord/lib/active_record/persistence.rb:564:in `_insert_record'`
lib/composite_primary_keys/persistence.rb:77:in `_create_record'
```
<details>
<summary>Full Backtrace</summary>
<pre>
bundle exec rails db:setup

Created database '[project]_test'
Running via Spring preloader in process 2631
rake aborted!
ArgumentError: wrong number of arguments (given 1, expected 2)
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/persistence.rb:564:in `_insert_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/composite_primary_keys-2a117c40935c/lib/composite_primary_keys/persistence.rb:77:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/counter_cache.rb:187:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/locking/optimistic.rb:84:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/encryption/encryptable_record.rb:174:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/attribute_methods/dirty.rb:236:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/callbacks.rb:445:in `block in _create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:110:in `run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:949:in `_run_create_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/callbacks.rb:445:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/timestamp.rb:114:in `_create_record'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/persistence.rb:1212:in `create_or_update'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/callbacks.rb:441:in `block in create_or_update'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/autosave_association.rb:379:in `around_save_collection_association'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:141:in `run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:949:in `_run_save_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/callbacks.rb:441:in `create_or_update'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/timestamp.rb:125:in `create_or_update'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/persistence.rb:712:in `save'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/validations.rb:49:in `save'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/transactions.rb:309:in `block in save'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/transactions.rb:365:in `block in with_transaction_returning_status'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:340:in `transaction'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/transactions.rb:361:in `with_transaction_returning_status'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/transactions.rb:309:in `save'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/suppressor.rb:52:in `save'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/persistence.rb:38:in `create'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:899:in `_create'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:103:in `block in create'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:914:in `_scoping'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:452:in `scoping'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:103:in `create'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:216:in `block in create_or_find_by'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:487:in `block in within_new_transaction'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:484:in `within_new_transaction'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:342:in `transaction'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/transactions.rb:212:in `transaction'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation/delegation.rb:122:in `public_send'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation/delegation.rb:122:in `block in method_missing'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:914:in `_scoping'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:452:in `scoping'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation/delegation.rb:122:in `method_missing'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:216:in `create_or_find_by'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/relation.rb:176:in `find_or_create_by'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/querying.rb:23:in `find_or_create_by'
/home/runner/work/[project]/[project]/db/seeds.rb:22:in `block in <top (required)>'
/home/runner/work/[project]/[project]/db/seeds.rb:21:in `each'
/home/runner/work/[project]/[project]/db/seeds.rb:21:in `<top (required)>'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/railties/lib/rails/engine.rb:556:in `load'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/railties/lib/rails/engine.rb:556:in `block in load_seed'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/execution_wrapper.rb:92:in `wrap'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/railties/lib/rails/engine.rb:642:in `block (2 levels) in <class:Engine>'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:130:in `instance_exec'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activesupport/lib/active_support/callbacks.rb:141:in `run_callbacks'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/railties/lib/rails/engine.rb:556:in `load_seed'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/tasks/database_tasks.rb:468:in `load_seed'
/home/runner/work/[project]/[project]/vendor/bundle/ruby/3.2.0/bundler/gems/rails-99f8b049f28f/activerecord/lib/active_record/railties/databases.rake:405:in `block (2 levels) in <top (required)>'
<internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:/opt/hostedtoolcache/Ruby/3.2.2/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:setup => db:seed
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
</pre>
</details>

This pull requests updates the methods signature for `sql_for_insert` in `composite_primary_keys` so it could take either 3 or 4 arguments and the call to `_insert_record` from one to two inside `_create_record`.

I'm also aware that Rails 7.1 is going to get some kind of support for composite primary keys, but I guess it would still make sense for `composite_primary_keys` to be Rails 7.1+ compatible to provide a smoother upgrade/migration path. 

I'm not sure if this is the proper and correct way to fix this. At least it's making my apps test pass and lets the app boot again. So I think this pull request is at least _a_ starting point for making `composite_primary_keys` Rails 7.1 compatible. 