### PR TITLE
Add trilogy GitHub workflow

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mariadb:

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mariadb:

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -30,7 +30,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mysql:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mysql:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -30,7 +30,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       postgres:

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       postgres:

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -28,7 +28,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -15,7 +15,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_PATH: vendor/bundle
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     env:
       BUNDLE_WITHOUT: "db2 oracle sqlserver postgresql mysql trilogy"

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2]
     runs-on: ${{matrix.os}}
     env:
       BUNDLE_WITHOUT: "db2 oracle sqlserver postgresql mysql trilogy"

--- a/.github/workflows/trilogy.yml
+++ b/.github/workflows/trilogy.yml
@@ -1,0 +1,45 @@
+name: trilogy
+
+on: [push, pull_request]
+
+jobs:
+  trilogy_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: [2.7, 3.0, 3.1, 3.2]
+    runs-on: ${{matrix.os}}
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: github
+          MYSQL_PASSWORD: github
+          MYSQL_DATABASE: composite_primary_keys_unittest
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      BUNDLE_WITHOUT: "db2 oracle sqlserver sqlite postgresql"
+      BUNDLE_JOBS: 4
+      BUNDLE_PATH: vendor/bundle
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
+      - name: Setup database config
+        run: cp test/connections/databases.ci.yml test/connections/databases.yml
+      - name: Prepare databases
+        run: bundle exec rake trilogy:rebuild_database
+        env:
+          MYSQL_ROOT_PASSWORD: root
+      - name: Trilogy test
+        run: bundle exec rake trilogy:test

--- a/.github/workflows/trilogy.yml
+++ b/.github/workflows/trilogy.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     runs-on: ${{matrix.os}}
     services:
       mysql:


### PR DESCRIPTION
# Purpose
To ensure nothing breaks the trilogy adapter we want there to be a workflow that runs tests against it. So add a GitHub workflow.

# Implementation
I attempted to add this here https://github.com/composite-primary-keys/composite_primary_keys/pull/607 but couldn't get it to work for some reason. When looking at why it works in the docker-compose file it became apparent that we needed to specify a version of mysql `5.7`.  The reason why may be due to [one of these reasons](https://github.com/trilogy-libraries/trilogy/issues?q=is%3Aissue+is%3Aopen+mysql+8+). I didn't spend too much time digging in.

~~I also spend some time to update the array to all be floats, because having a string in the array didn't feel quite right 😄~~ https://github.com/composite-primary-keys/composite_primary_keys/pull/589. I also updated the actions checkout to the latest version.