### PR TITLE
Fix Error for Array-Based Composite Keys in nested_attribute

### DIFF
--- a/lib/composite_primary_keys/nested_attributes.rb
+++ b/lib/composite_primary_keys/nested_attributes.rb
@@ -66,7 +66,7 @@ module ActiveRecord
             # Make sure we are operating on the actual object which is in the association's
             # proxy_target array (either by finding it, or adding it if not found)
             # Take into account that the proxy_target may have changed due to callbacks
-             target_record = cpk_detect_record(attributes['id'], association.target)
+            target_record = cpk_detect_record(attributes['id'], association.target)
             if target_record
               existing_record = target_record
             else

--- a/lib/composite_primary_keys/nested_attributes.rb
+++ b/lib/composite_primary_keys/nested_attributes.rb
@@ -61,12 +61,12 @@ module ActiveRecord
           unless reject_new_record?(association_name, attributes)
             association.reader.build(attributes.except(*UNASSIGNABLE_KEYS))
           end
-        elsif existing_record = existing_records.detect { |record| record.id.to_s == attributes["id"].to_s }
+        elsif existing_record = cpk_detect_record(attributes['id'], existing_records)
           unless call_reject_if(association_name, attributes)
             # Make sure we are operating on the actual object which is in the association's
             # proxy_target array (either by finding it, or adding it if not found)
             # Take into account that the proxy_target may have changed due to callbacks
-            target_record = association.target.detect { |record| record.id.to_s == attributes["id"].to_s }
+             target_record = cpk_detect_record(attributes['id'], association.target)
             if target_record
               existing_record = target_record
             else

--- a/test/test_nested_attributes.rb
+++ b/test/test_nested_attributes.rb
@@ -64,4 +64,27 @@ class TestNestedAttributes < ActiveSupport::TestCase
     assert_equal(reference_code.code_label, 'XX')
     assert_equal(reference_code.abbreviation, 'Xx')
   end
+
+  def test_nested_atttribute_update_4
+    code_id = 1003
+
+    reference_type = reference_types(:name_prefix)
+    reference_type.update :reference_codes_attributes => [{
+      :reference_code => code_id,
+      :code_label => 'XX',
+      :abbreviation => 'Xx'
+    }]
+    assert_not_nil ReferenceCode.find_by_reference_code(code_id)
+    reference_code = ReferenceCode.find_by_reference_code(code_id)
+    # directly pass :id as a array 
+    reference_type.update :reference_codes_attributes => [{
+      :id => [reference_type.reference_type_id, code_id],
+      :code_label => 'AAA',
+      :abbreviation => 'Aaa'
+    }]
+    
+    reference_code = ReferenceCode.find_by_reference_code(code_id)
+    assert_kind_of(ReferenceCode, reference_code)
+    assert_equal(reference_code.code_label, 'AAA')
+  end
 end


### PR DESCRIPTION
# Problem Description

I recently updated my project to Rails 6 and faced a testing error when passing a composite key as an array to nested_attribute.

I have added a test case for this error. Please refer to this [test case](https://github.com/composite-primary-keys/composite_primary_keys/commit/41f81c8044776bc8d9c69b071386050e8dc391c1) if necessary.

# PR Description

Since [this commit](https://github.com/composite-primary-keys/composite_primary_keys/issues/474), record detection in nested_attributes.rb has been conducted using the `detect` method instead of `cpk_detect_record`.

I could not find any mention of this change, and considering that `cpk_detect_record` still exists in `nested_attributes.rb` but is not used, I created this PR.

This PR reverts to the approach used prior to the introduction of this [PR](https://github.com/composite-primary-keys/composite_primary_keys/commit/846b5e86089f866556769658de53ff9d9f82ff52#diff-f546fbccae6c9d276ea04e316415d39c2cc08c040f23119978d57f1fe8197406).

If we are intended to use `CompositePrimaryKeys::CompositeKeys` for creating primary keys as demonstrated in the test case (i.e., if the above change was intentional), I will close this PR.

Also, a quick thanks to the maintainers for their ongoing work on the project.