### PR TITLE
Fix scope overriding join relation query

### DIFF
--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -6,6 +6,12 @@ module ActiveRecord
         scope_chain_items = join_scopes(table, predicate_builder)
         klass_scope       = klass_join_scope(table, predicate_builder)
 
+        if type
+          klass_scope.where!(type => foreign_klass.polymorphic_name)
+        end
+
+        scope_chain_items.inject(klass_scope, &:merge!)
+
         key         = join_primary_key
         foreign_key = join_foreign_key
 
@@ -14,15 +20,11 @@ module ActiveRecord
         constraint = cpk_join_predicate(table, key, foreign_table, foreign_key)
         klass_scope.where!(constraint)
 
-        if type
-          klass_scope.where!(type => foreign_klass.polymorphic_name)
-        end
-
         if klass.finder_needs_type_condition?
           klass_scope.where!(klass.send(:type_condition, table))
         end
 
-        scope_chain_items.inject(klass_scope, &:merge!)
+        klass_scope
       end
     end
 


### PR DESCRIPTION
Adding scopes after the join relation removes the join query from the generated SQL.

Rearrange code to match [rails 7.0 method](https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/reflection.rb#L175)

Example:
```rb
class User < ApplicationRecord
  has_many :features, -> { enabled }
end

class Feature < ApplicationRecord
  scope :enabled, -> { where.not(user_id: nil).where(enabled: true) }
end

# User.joins(:features).to_sql
# INNER JOIN query won't include `users.id = features.user_id` but only `features.user_id IS NOT NULL`
# when the expected is both
```