### PR TITLE
AR 6.1: Fix object comparison for models with composite keys

### DIFF
--- a/lib/composite_primary_keys/core.rb
+++ b/lib/composite_primary_keys/core.rb
@@ -16,6 +16,29 @@ module ActiveRecord
       super
     end
 
+    def primary_key_values_present?
+      if self.composite?
+        id.all? {|key| !key.nil?}
+      else
+        !id.nil?
+      end
+    end
+
+    def ==(comparison_object)
+      super ||
+        comparison_object.instance_of?(self.class) &&
+        primary_key_values_present? &&
+        comparison_object.id == id
+    end
+
+    def hash
+      if primary_key_values_present?
+        self.class.hash ^ id.hash
+      else
+        super
+      end
+    end
+
     module ClassMethods
       def find(*ids) # :nodoc:
         # We don't have cache keys for this stuff yet

--- a/test/test_equal.rb
+++ b/test/test_equal.rb
@@ -1,26 +1,55 @@
 require File.expand_path('../abstract_unit', __FILE__)
 
 class TestEqual < ActiveSupport::TestCase
-  fixtures :capitols
+  fixtures :restaurants, :products
 
-  def test_new
-    assert_equal(Capitol.new, Capitol.new)
-  end
+  ############################################################
+  ### Tests for Product model with single primary key (id) ###
+  ############################################################
 
-  def test_same_new
-    it = Capitol.new
-    assert_equal(it, it)
-  end
-
-  def test_same
-    first = Capitol.find(['Canada', 'Ottawa'])
-    second = Capitol.find(['Canada', 'Ottawa'])
+  def test_single_same
+    first = Product.find(1)
+    second = Product.find(1)
     assert_equal(first, second)
   end
 
   def test_different
-    first = Capitol.find(['Mexico', 'Mexico City'])
-    second = Capitol.find(['Canada', 'Ottawa'])
+    first = Product.find(1)
+    second = Product.find(2)
     assert_not_equal(first, second)
+  end
+
+  def test_two_new_objects_are_not_equal
+    assert_not_equal(Product.new, Product.new)
+  end
+
+  def test_same_new_object_is_equal_to_itself
+    it = Product.new
+    assert_equal(it, it)
+  end
+
+  #####################################################################################
+  ### Tests for Restaurant model with composite primary key (franchise_id, store_id) ##
+  #####################################################################################
+
+  def test_composite_same
+    first = Restaurant.find([1, 1])
+    second = Restaurant.find([1, 1])
+    assert_equal(first, second)
+  end
+
+  def test_composite_different
+    first = Restaurant.find([1, 1])
+    second = Restaurant.find([2, 2])
+    assert_not_equal(first, second)
+  end
+
+  def test_composite_two_new_objects_are_not_equal
+    assert_not_equal(Restaurant.new, Restaurant.new)
+  end
+
+  def test_composite_same_new_object_is_equal_to_itself
+    it = Restaurant.new
+    assert_equal(it, it)
   end
 end

--- a/test/test_hash.rb
+++ b/test/test_hash.rb
@@ -1,0 +1,73 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestHash < ActiveSupport::TestCase
+  fixtures :restaurants, :products
+
+  ############################################################
+  ### Tests for Product model with single primary key (id) ###
+  ############################################################
+
+  def test_single_same_object_has_the_same_hash
+    first = Product.find(1)
+    second = Product.find(1)
+    assert_equal(first.hash, second.hash)
+  end
+
+  def test_single_different_objects_have_different_hashes
+    first = Product.find(1)
+    second = Product.find(2)
+    assert_not_equal(first.hash, second.hash)
+  end
+
+  def test_single_persisted_object_hash_is_based_on_primary_key
+    first = Product.find(1)
+    second = Product.find(1)
+
+    assert_equal(first.hash, second.hash)
+    first.name = 'new name'
+    assert_equal(first.hash, second.hash)
+  end
+
+  def test_single_two_new_objects_have_different_hashes
+    assert_not_equal(Product.new.hash, Product.new.hash)
+  end
+
+  def test_single_same_new_object_has_the_same_hash
+    it = Product.new
+    assert_equal(it.hash, it.hash)
+  end
+
+  #####################################################################################
+  ### Tests for Restaurant model with composite primary key (franchise_id, store_id) ##
+  #####################################################################################
+
+  def test_composite_same_object_has_the_same_hash
+    first = Restaurant.find([1, 1])
+    second = Restaurant.find([1, 1])
+    assert_equal(first.hash, second.hash)
+  end
+
+  def test_composite_different_objects_have_different_hashes
+    first = Restaurant.find([1, 1])
+    second = Restaurant.find([2, 2])
+    assert_not_equal(first.hash, second.hash)
+  end
+
+  def test_composite_persisted_object_hash_is_based_on_primary_key
+    first = Restaurant.find([1, 1])
+    second = Restaurant.find([1, 1])
+
+    assert_equal(first.hash, second.hash)
+    first.name = 'new name'
+    assert_equal(first.hash, second.hash)
+  end
+
+  def test_composite_two_new_objects_have_different_hashes
+    assert_not_equal(Restaurant.new.hash, Restaurant.new.hash)
+  end
+
+  def test_composite_same_new_object_has_the_same_hash
+    it = Restaurant.new
+    assert_equal(it.hash, it.hash)
+  end
+end


### PR DESCRIPTION
Addresses issue https://github.com/composite-primary-keys/composite_primary_keys/issues/616

## Overview - overwriting `==`

In `ActiveRecord` two new (not yet persisted) AR objects are _not_ considered equal, even if all their attributes (including primary key) are `nil`.

We want the same behaviour for models with composite primary key handled by `composite_primary_keys` gem. To do that, we override `==` method. In the [AR source](https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/core.rb#L637-L643), there is a special key for primary key being empty (check using `!id.nil?`). For composite primary key, we will use `id.all? {|key| !key.nil?}` to check that.

I also took inspiration from [AR 7.2](https://github.com/rails/rails/blob/33beb0a38db1c058123a8e3cc298cad918adfe32/activerecord/lib/active_record/attribute_methods/composite_primary_key.rb#L16-L22) where a helper method `primary_key_values_present?` is defined that differs based on whether the primary key is singular or composite.

## Overwriting `hash`

`hash` method on AR model also uses `!id.nil?` and thus also doesn't work well for models with composite primary key. it also gets improved in this PR.

## Tests

I wrote tests both for models with single and with composite primary keys. I switched to using `Restaurant` model instead of `Capitol` because I wanted a table that has a composite primary key _and_ some other columns (for the purposes of `test_composite_persisted_object_hash_is_based_on_primary_key` test case).