### PR TITLE
AR 6.1: Fix `update_all` to update loaded associations

### DIFF
--- a/test/test_relation.rb
+++ b/test/test_relation.rb
@@ -1,0 +1,27 @@
+require File.expand_path('../abstract_unit', __FILE__)
+
+class TestRelation < ActiveSupport::TestCase
+  fixtures :users, :readings
+  
+  def test_update_all_updates_db_records
+    user = User.find(1)
+    assert_equal [4, 5], user.readings.map(&:rating)
+
+    user.readings.update_all(rating: 3)
+
+    # Reload to check that the records were updated in the DB
+    user.readings.reload
+    assert_equal [3, 3], user.readings.map(&:rating)
+  end
+
+  def test_update_all_updates_loaded_association
+    user = User.find(1)
+    assert_equal [4, 5], user.readings.map(&:rating)
+
+    user.readings.update_all(rating: 3)
+
+    # No reload to check that not only the records were updated in the DB
+    # but also in the loaded association
+    assert_equal [3, 3], user.readings.map(&:rating)
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/composite-primary-keys/composite_primary_keys/issues/619

## Overview

In ActiveRecord 6.1, calling `update_all` on association (ex. `user.readings.update_all(rating: 3)`) not only updates the records in the DB, but also updates the loaded association objects. In other words, when you then use `user.readings`, they will have updated `rating` values.

When `composite_primary_key` gem is used, this behaviour is different, _even for models without composite primary key defined_ (because `update_all` in `ActiveRecord::Relation` is overwritten for all AR models).

This PR fixes it. I changed the `update_all` and `delete_all` methods to more closely resemble those from [Rails 6.1 source](https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/relation.rb) (with the important difference of how `where` constraints are built for composite primary key models).