### PR TITLE
Ignore orders for delete_all/update_all queries.

### DIFF
--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -37,7 +37,6 @@ module ActiveRecord
 
       stmt.take(arel.limit)
       stmt.offset(arel.offset)
-      stmt.order(*arel.orders)
 
       if updates.is_a?(Hash)
         if klass.locking_enabled? &&
@@ -81,7 +80,6 @@ module ActiveRecord
 
       stmt.take(arel.limit)
       stmt.offset(arel.offset)
-      stmt.order(*arel.orders)
 
       affected = klass.connection.delete(stmt, "#{klass} Destroy")
 

--- a/test/fixtures/tariff.rb
+++ b/test/fixtures/tariff.rb
@@ -1,5 +1,6 @@
 class Tariff < ActiveRecord::Base
-	self.primary_keys = [:tariff_id, :start_date]
-	has_many :product_tariffs, :foreign_key => [:tariff_id, :tariff_start_date], :dependent => :delete_all
-	has_many :products, :through => :product_tariffs, :foreign_key => [:tariff_id, :tariff_start_date]
+  self.primary_keys = [:tariff_id, :start_date]
+  has_many :product_tariffs, :foreign_key => [:tariff_id, :tariff_start_date], :dependent => :delete_all
+  has_many :products, :through => :product_tariffs, :foreign_key => [:tariff_id, :tariff_start_date]
+  default_scope { order(created_at: :asc) }
 end

--- a/test/test_calculations.rb
+++ b/test/test_calculations.rb
@@ -12,7 +12,7 @@ class TestCalculations < ActiveSupport::TestCase
     expected = {Date.today => 2,
                 Date.today.next => 1}
 
-    assert_equal(expected, Tariff.group(:start_date).count)
+    assert_equal(expected, Tariff.unscoped.group(:start_date).count)
   end
 
   def test_count_distinct

--- a/test/test_delete.rb
+++ b/test/test_delete.rb
@@ -30,6 +30,13 @@ class TestDelete < ActiveSupport::TestCase
     assert_equal(5, deleted)
   end
 
+  def test_delete_all_default_order
+    refute_empty(Tariff.all)
+    deleted = Tariff.delete_all
+    assert_empty(Tariff.all)
+    assert_equal(3, deleted)
+  end
+
   def test_delete_all_with_join
     tested_delete_all = false
     Arel::Table.engine = nil # should not rely on the global Arel::Table.engine

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -73,6 +73,14 @@ class TestUpdate < ActiveSupport::TestCase
     end
   end
 
+  def test_update_all_default_order
+    Tariff.update_all(amount: 1337)
+
+    Tariff.all.each do |reference_code|
+      assert_equal(1337, reference_code.amount)
+    end
+  end
+
   def test_update_all_join
     tested_update_all = false
     Arel::Table.engine = nil # should not rely on the global Arel::Table.engine


### PR DESCRIPTION
**- What is it good for**

While upgrading an application from Rails 5.2 to 6.1 (CPK 11.2 -> 13.0) some specs broke. I tracked it down to `Entity.delete_all` calls on the setup of the test suite. Then I found the broken SQL statement and about an syntax error near to `ORDER` - there is nothing to order at the top-level for `DELETE` and `UPDATE` queries. This is caused by a `default_scope { order(created_at: :asc) }`.

<details>
  <summary>Click for Details</summary>

### ActiveRecord::Base.delete_all

```ruby
class Tariff < ActiveRecord::Base
  default_scope { order(created_at: :asc) }
end

Tariff.delete_all
```

```sql
DELETE FROM "tariffs"
WHERE ("tariffs"."tariff_id", "tariffs"."start_date") IN (
  SELECT "tariffs"."tariff_id", "tariffs"."start_date"
  FROM "tariffs"
  ORDER BY "tariffs"."created_at" ASC
)
ORDER BY "tariffs"."created_at" ASC -- syntax error due to the
                                    -- default scope/order

-- ActiveRecord::StatementInvalid: PG::SyntaxError:
--   ERROR:  syntax error at or near "ORDER"
-- LINE 1: ...OM "tariffs" ORDER BY "tariffs"."created_at" ASC) ORDER BY "...
```

### ActiveRecord::Base.update_all

```ruby
class Tariff < ActiveRecord::Base
  default_scope { order(created_at: :asc) }
end

Tariff.update_all(amount: 1337)
```

```sql
UPDATE "tariffs"
WHERE ("tariffs"."tariff_id", "tariffs"."start_date") IN (
  SELECT "tariffs"."tariff_id", "tariffs"."start_date"
  FROM "tariffs"
  ORDER BY "tariffs"."created_at" ASC
)
ORDER BY "tariffs"."created_at" ASC -- syntax error due to the
                                    -- default scope/order

-- ActiveRecord::StatementInvalid: PG::SyntaxError:
--   ERROR:  syntax error at or near "ORDER"
-- LINE 1: ...OM "tariffs" ORDER BY "tariffs"."created_at" ASC) ORDER BY "...
```

</details>

**- What I did**

Just removed the ordering on `delete_all` and `update_all` SQL statement assembly and added tests for it. I fixed the issue at the `ar_6.1.x` branch, but I'm sure this must be ported back to 6.0 and  master. 

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/user-attachments/assets/ebd2e92e-84f4-4eb7-98c0-dd1d6c25f312)