### PR TITLE
Quote Column Names

### DIFF
--- a/lib/composite_primary_keys/arel/to_sql.rb
+++ b/lib/composite_primary_keys/arel/to_sql.rb
@@ -5,9 +5,9 @@ module Arel
         values = o.map do |key|
           case key
             when Arel::Attributes::Attribute
-              "#{key.relation.name}.#{key.name}"
+              "#{quote_table_name(key.relation.name)}.#{quote_column_name(key.name)}"
             else
-              key
+              quote_column_name(key)
           end
         end
         collector << "(#{values.join(', ')})"

--- a/lib/composite_primary_keys/relation.rb
+++ b/lib/composite_primary_keys/relation.rb
@@ -173,8 +173,8 @@ module ActiveRecord
     #
     # UPDATE `reference_codes`
     # SET ...
-    # WHERE (reference_codes.reference_type_id, reference_codes.reference_code) IN
-    #  (SELECT reference_type_id,reference_code
+    # WHERE (`reference_codes`.`reference_type_id`, `reference_codes`.`reference_code`) IN
+    #  (SELECT `reference_type_id`,`reference_code`
     #   FROM (SELECT DISTINCT `reference_codes`.`reference_type_id`, `reference_codes`.`reference_code`
     #         FROM `reference_codes`) __active_record_temp)
     def cpk_mysql_subquery(stmt)
@@ -189,7 +189,9 @@ module ActiveRecord
       # to work with MySQL 5.7.6 which sets optimizer_switch='derived_merge=on'
       subselect.distinct unless arel.limit || arel.offset || arel.orders.any?
 
-      key_name = arel_attributes.map(&:name).join(',')
+      key_name = arel_attributes.map(&:name).map do |name|
+        connection.quote_column_name(name)
+      end.join(',')
 
       manager = Arel::SelectManager.new(subselect.as("__active_record_temp")).project(Arel.sql(key_name))
 


### PR DESCRIPTION
The current MySQL query generation logic does not quote the primary keys in generated subqueries, which can result in queries like:

```mysql
DELETE FROM `datablock_storage_kvps` WHERE (datablock_storage_kvps.project_id, datablock_storage_kvps.key) IN (SELECT project_id,key FROM (SELECT DISTINCT `datablock_storage_kvps`.`project_id`, `datablock_storage_kvps`.`key` FROM `datablock_storage_kvps` WHERE `datablock_storage_kvps`.`project_id` = 13) __active_record_temp)
```

Which can, depending on the names given to the keys (in this case, "key"), result in errors like:

    ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'key FROM (SELECT DISTINCT `datablock_storage_kvps`.`project_id`, `datablock_stor' at line 1

This PR adds logic to quote the parameters in both the `WHERE` and `SELECT` clauses, resulting in a query like:

```mysql
DELETE FROM `datablock_storage_kvps` WHERE (`datablock_storage_kvps`.`project_id`, `datablock_storage_kvps`.`key`) IN (SELECT `project_id`,`key` FROM (SELECT DISTINCT `datablock_storage_kvps`.`project_id`, `datablock_storage_kvps`.`key` FROM `datablock_storage_kvps` WHERE `datablock_storage_kvps`.`project_id` = 13) __active_record_temp)
```